### PR TITLE
fix: add deploy workflow and fix .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,7 @@ temp.db
 .idea/
 .aider*
 .hermes
+*.deploy_config
+
+# Local analysis/dev artifacts
+deployment-analysis/


### PR DESCRIPTION
## Changes

- **Add `deploy.yml`**: GitHub Actions workflow for auto-deploy to DigitalOcean droplet on merge to `master`
  - SSH deploy via `webfactory/ssh-agent` + `rsync`
  - Installs Python deps in venv, restarts systemd service
  - Requires `DROPLET_SSH_KEY` secret (see setup instructions below)

- **Fix `.gitignore`**: Add `*.deploy_config` and `deployment-analysis/`
  - `*.deploy_config` contains SSH credentials — must never be committed
  - `deployment-analysis/` contains local dev database and logs

## Setup required before merge

1. Add `DROPLET_SSH_KEY` secret to GitHub repo settings:
   - Copy contents of `~/.ssh/dohp` (your droplet SSH private key)
   - Go to: Settings → Secrets and variables → Actions → New repository secret
   - Name: `DROPLET_SSH_KEY`, Value: paste the key

2. After merge, the deploy workflow will run automatically on push to `master`

## Workflow

`fix/*` branch → PR → 4 green checks (CI: 3 Python versions + lint) → merge to master → auto-deploy to droplet