### PR TITLE
feat: add .git/config, .git/HEAD, security.txt responses to ConfigDisclosureHandler

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -286,6 +286,46 @@ test/
 
 5. **Subprocess git pull** — The `update.py:pull()` runs `git pull` and `pip install -r requirements.txt` in a subprocess. This is a security risk in production — consider pinning versions.
 
+## Handler Coverage Analysis
+
+### Current Handlers (11 total)
+
+| Handler | Domain | Purpose |
+|---------|--------|---------|
+| WordPressHandler | wordpress | WordPress CMS emulation |
+| DrupalHandler | drupal | Drupal CMS emulation |
+| PhpMyAdminHandler | phpmyadmin | phpMyAdmin database admin |
+| CPanelHandler | cpanel | cPanel/WHM control panel |
+| JenkinsHandler | jenkins | Jenkins CI/CD server |
+| TomcatHandler | tomcat | Apache Tomcat servlet container |
+| WebDAVHandler | webdav | WebDAV file sharing |
+| BitrixHandler | bitrix | Bitrix CMS emulation |
+| ConfigDisclosureHandler | config_disclosure | Sensitive file disclosure (config files, backups) |
+| GenericHandler | generic | Fallback for unmatched paths + "monster page" |
+
+### Known Coverage Gaps
+
+Production data shows **97% of bot traffic hits the root path `/`** which currently falls to GenericHandler. See `docs/production-analysis-handler-coverage.md` for a complete analysis.
+
+**High-priority gaps:**
+- Root path `/` — 17,033 hits (needs targeted responses by User-Agent)
+- Favicon `/favicon.ico` — 36 hits (bot fingerprinting trigger)
+- Login paths `/login`, `/j_spring_security_check` — Spring Security emulation needed
+- Environment files `/.env` — ConfigDisclosureHandler expansion
+- API endpoints `/api/*`, `/v*/api-docs`, Swagger — New API handler needed
+- Next.js paths `/_next/*` — New NextJS handler needed
+- PHP eval RCE `eval-stdin.php` patterns — New EvalStdin handler needed
+
+### Adding a New Handler
+
+1. Create `manyfaced/handlers/<name>_handler.py` extending `HTTPHandlerBase`
+2. Define `domain`, `PATH_PATTERNS`, and `generate_response()` method
+3. Register in `handlers/__init__.py` (add to `_HANDLER_CLASSES`)
+4. Add service info to `generic_handler._SERVICE_INFO` for monster page inclusion
+5. Write tests in `test/test_<name>_handler.py`
+
+See existing handlers for patterns — `wordpress_handler.py` is a good reference for a complete implementation.
+
 ## Debugging Tips
 
 - `-v` (verbose) mode prints every bot interaction

--- a/docs/production-analysis-handler-coverage.md
+++ b/docs/production-analysis-handler-coverage.md
@@ -1,0 +1,183 @@
+# Production Analysis: Handler Coverage Gaps
+
+**Date:** 2026-05-05  
+**Source:** honeypot.sqlite database (all-time) + recent journalctl logs  
+**Total recorded bots:** ~17,500+ dialogue entries  
+
+---
+
+## Executive Summary
+
+The honeypot currently has **11 specialized HTTP handlers** covering WordPress, Drupal, phpMyAdmin, cPanel/WHM, Jenkins, Tomcat, WebDAV, Bitrix, and config disclosure. However, production data reveals significant coverage gaps — the vast majority of bot traffic hits paths that fall through to the generic handler.
+
+### Key Finding: 97% of all requests hit the root path `/` (17,033 hits)
+
+This is the single biggest gap. The root path currently triggers only the `GenericHandler`, which serves a "monster page" — but this could be dramatically improved with targeted responses for common root-path probing patterns.
+
+---
+
+## Current Handler Coverage Matrix
+
+| Handler | Domain | Status | Production Hits (top paths) |
+|---------|--------|--------|---------------------------|
+| WordPress | wordpress | ✅ Active | 1x `/wp-login.php`, 1x `/wp-admin` |
+| Drupal | drupal | ✅ Active | Minimal hits |
+| phpMyAdmin | phpmyadmin | ✅ Active | No top-50 hits |
+| cPanel/WHM | cpanel | ✅ Active | 1x `/whm/`, 1x `/webmail/` |
+| Jenkins | jenkins | ✅ Active | No top-50 hits |
+| Tomcat | tomcat | ✅ Active | No top-50 hits |
+| WebDAV | webdav | ✅ Active | No top-50 hits |
+| Bitrix | bitrix | ✅ Active | No top-50 hits |
+| Config Disclosure | config_disclosure | ✅ Active | No top-50 hits |
+| Generic | generic | ✅ Fallback | **17,033x root path** + all unmatched |
+
+---
+
+## Missing/Incomplete Handler Coverage
+
+### 🔴 CRITICAL: High-Frequency Unhandled Paths
+
+#### 1. Root Path `/` — 17,033 hits (97% of traffic)
+**Current:** GenericHandler "monster page"  
+**Problem:** Bots hitting root are the largest group but get a generic response. Many will leave without probing deeper.  
+**Recommendation:** Create a `RootProbeHandler` that serves different responses based on:
+- User-Agent (scanners vs. automated tools)
+- Request headers (Accept, Referer)
+- Time-based rotation of fake service banners
+
+#### 2. Favicon — 36 hits
+**Path:** `/favicon.ico`  
+**Current:** Falls to generic handler  
+**Recommendation:** Serve a realistic favicon that triggers bot fingerprinting (some scanners check for specific favicon hashes).
+
+#### 3. Login Paths — 8x `/login`, 4x `/j_spring_security_check`
+**Paths:** `/login`, `/j_spring_security_check`, `/user/register`, `/user/`  
+**Current:** Falls to generic handler  
+**Recommendation:** Create a `SpringSecurityHandler` or extend existing handlers with Spring Security login page emulation. The `/j_spring_security_check` path is specifically from Spring Security applications — this is a distinct attack pattern worth capturing separately.
+
+### 🟡 HIGH: Medium-Frequency Unhandled Paths (2-5 hits each)
+
+#### 4. Environment Files — 4x `/.env`
+**Path:** `/.env`  
+**Current:** Falls to generic handler  
+**Recommendation:** Add to ConfigDisclosureHandler or create dedicated `.env` response with fake database credentials, API keys, and secrets. This is a very common scanner target.
+
+#### 5. Sitemap — 3x `/sitemap.xml`
+**Path:** `/sitemap.xml`  
+**Current:** Falls to generic handler  
+**Recommendation:** Serve a realistic sitemap.xml that lists fake pages across all registered handlers (WordPress posts, phpMyAdmin paths, Jenkins jobs, etc.). This encourages deeper probing.
+
+#### 6. API Endpoints — 3x each: `/api/route`, `/api`
+**Paths:** `/api`, `/api/route`, `/v2/api-docs`, `/v3/api-docs`, `/swagger/v1/swagger.json`, `/swagger-ui.html`, `/swagger/index.html`, `/swagger.json`  
+**Current:** Falls to generic handler  
+**Recommendation:** Create an `APIHandler` that serves:
+- Fake OpenAPI/Swagger specs with endpoints pointing to other handlers
+- API versioning responses (`/v2/api-docs`, `/v3/api-docs`)
+- GraphQL endpoint emulation (`/graphql`)
+
+#### 7. Next.js Paths — 3x each: `/_next/server`, `/_next`
+**Paths:** `/_next`, `/_next/server`  
+**Current:** Falls to generic handler  
+**Recommendation:** Create a `NextJSHandler` that serves realistic Next.js responses including:
+- `_next/static/` asset paths
+- API routes (`/_next/api/...`)
+- Page router paths
+
+#### 8. WebSocket/SSE — 2x each: `/sse`, `/mcp`
+**Paths:** `/sse`, `/mcp`  
+**Current:** Falls to generic handler (HTTP only, no WS support)  
+**Recommendation:** These are emerging attack vectors. Even HTTP-level responses with appropriate headers (`Upgrade: websocket`) would capture more bot behavior.
+
+#### 9. App Root — 2x `/app`
+**Path:** `/app`  
+**Current:** Falls to generic handler  
+**Recommendation:** Could be handled by GenericHandler with a specific response, or added as a path pattern in an existing handler.
+
+#### 10. SDK Endpoints — 2x `/SDK/webLanguage`
+**Path:** `/SDK/webLanguage`  
+**Current:** Falls to generic handler  
+**Recommendation:** Common in Java/Spring applications. Could be part of a `SpringHandler`.
+
+#### 11. Security.txt — 2x `/.well-known/security.txt`, 1x `/security.txt`
+**Paths:** `/.well-known/security.txt`, `/security.txt`  
+**Current:** Falls to generic handler  
+**Recommendation:** Serve a realistic security.txt with contact email, PGP key, and preferred-encryption fields. This is increasingly common in scanner activity.
+
+#### 12. Git Config — 2x `/.git/config`
+**Path:** `/.git/config` (not just `/.git`)  
+**Current:** Falls to generic handler  
+**Recommendation:** Add to ConfigDisclosureHandler. Serve a realistic `.git/config` with remote URLs and credentials.
+
+#### 13. Path Traversal — 2x URL-encoded variants
+**Path:** `/..%2F..%2F..%2F..%2F..%2F..%2Fetc%2Fpasswd`  
+**Current:** Falls to generic handler  
+**Recommendation:** Already partially handled by GenericHandler's path traversal detection, but could be more specific with realistic `/etc/passwd` content.
+
+### 🟠 MEDIUM: Single-Hit Patterns Worth Capturing
+
+#### 14. PHP Eval RCE — Multiple paths
+**Paths:** `/*/vendor/phpunit/phpunit/src/Util/PHP/eval-stdin.php` (15+ variants)  
+**Current:** Falls to generic handler  
+**Recommendation:** This is a known phpunit RCE exploit pattern. Create an `EvalStdinHandler` that serves realistic PHP error pages with stack traces, encouraging further exploitation attempts.
+
+#### 15. Swagger/OpenAPI — Multiple paths
+**Paths:** `/swagger/v1/swagger.json`, `/swagger-ui.html`, `/swagger/index.html`, `/swagger.json`, `/swagger-ui.html`  
+**Current:** Falls to generic handler (see #6 API Endpoints)  
+**Recommendation:** Part of the APIHandler recommendation above.
+
+#### 16. Docker Registry — 1x `/v2/_catalog`
+**Path:** `/v2/_catalog`  
+**Current:** Falls to generic handler  
+**Recommendation:** Create a `DockerRegistryHandler` that serves fake registry responses with image listings, encouraging push/pull attempts.
+
+#### 17. Wiki — 1x `/wiki`
+**Path:** `/wiki`  
+**Current:** Falls to generic handler  
+**Recommendation:** Could be part of a general CMS handler or a dedicated Confluence/MediaWiki handler.
+
+#### 18. Server Status — 1x `/server-status`, 1x `/server`
+**Paths:** `/server-status`, `/server`  
+**Current:** Falls to generic handler  
+**Recommendation:** Apache/Nginx server-status pages are common scanner targets. Serve fake status pages with active connections, request counts, etc.
+
+#### 19. ThinkPHP RCE — 1x complex path
+**Path:** `/public/index.php?s=/index/\think\app/invokefunction&function=call_user_func_array&vars[0]=md5&vars[1][]=Hello`  
+**Current:** Falls to generic handler  
+**Recommendation:** Create a `ThinkPHPHandler` that emulates ThinkPHP's routing and serves realistic RCE responses.
+
+---
+
+## Priority Recommendations
+
+### Phase 1: Quick Wins (High Impact, Low Effort)
+1. **Root path enhancement** — Add specific root-path responses in GenericHandler based on User-Agent patterns
+2. **ConfigDisclosure expansion** — Add `/.env`, `/.git/config`, `/security.txt` to existing handler
+3. **Favicon response** — Serve a realistic favicon.ico that triggers bot fingerprinting
+
+### Phase 2: New Handlers (Medium Effort)
+4. **APIHandler** — Handle `/api/*`, `/v*/api-docs`, Swagger paths, OpenAPI specs
+5. **SpringSecurityHandler** — Handle `/j_spring_security_check`, `/login`, Spring-specific patterns
+6. **NextJSHandler** — Handle `/_next/*` paths with realistic Next.js responses
+7. **EvalStdinHandler** — Handle the phpunit eval-stdin.php RCE pattern
+
+### Phase 3: Advanced (Higher Effort)
+8. **DockerRegistryHandler** — Handle `/v2/_catalog` and Docker registry API
+9. **ThinkPHPHandler** — Handle ThinkPHP routing and RCE patterns
+10. **WebSocket/SSE support** — Upgrade http_handler to handle WebSocket upgrades for `/sse`, `/mcp`
+
+---
+
+## Data Quality Notes
+
+- The `46.166.165.71:805` entry (29 hits) appears to be a malformed path from the client honeypot's own reporting — this is likely an internal artifact, not a real bot request.
+- Most single-hit paths are from automated scanners that probe many paths quickly and move on. Capturing these with realistic responses could increase dwell time and data quality.
+- The root path dominance (97%) suggests bots are using broad-spectrum scanners that hit `/` first before probing specific paths.
+
+---
+
+## Metrics to Track Post-Implementation
+
+1. **Root path response diversity** — Are different User-Agents getting different responses?
+2. **Dwell time improvement** — Do bots stay longer when they encounter realistic responses for their probe paths?
+3. **Handler match rate** — What percentage of requests hit a specialized handler vs. generic fallback?
+4. **New path discovery** — Are new bot patterns emerging that need additional handlers?

--- a/manyfaced/handlers/config_disclosure_handler.py
+++ b/manyfaced/handlers/config_disclosure_handler.py
@@ -325,10 +325,7 @@ class ConfigDisclosureHandler(HTTPHandlerBase):
                 body, 200, "OK", {"Content-Type": "text/html"}
             ), self.DETECTED_ID
 
-        if (
-            "/.git/config" in path_lower
-            or "/.git/head" in path_lower
-        ):
+        if "/.git/config" in path_lower or "/.git/head" in path_lower:
             if "/.git/head" in path_lower:
                 body = self._git_head()
             else:
@@ -342,7 +339,6 @@ class ConfigDisclosureHandler(HTTPHandlerBase):
             return self._build_http_response(
                 body, 200, "OK", {"Content-Type": "text/plain"}
             ), self.DETECTED_ID
-
 
         # Default: serve wp-config.php as the most common target
         body = self._wp_config_php()

--- a/manyfaced/handlers/config_disclosure_handler.py
+++ b/manyfaced/handlers/config_disclosure_handler.py
@@ -155,6 +155,11 @@ class ConfigDisclosureHandler(HTTPHandlerBase):
         "/sql/",
         "/mysql/",
         "/postgres/",
+        "/.git/config",
+        "/.git/head",
+        "/.git/index",
+        "/security.txt",
+        "/.well-known/security.txt",
     ]
     DETECTED_ID = 1
 
@@ -319,6 +324,25 @@ class ConfigDisclosureHandler(HTTPHandlerBase):
             return self._build_http_response(
                 body, 200, "OK", {"Content-Type": "text/html"}
             ), self.DETECTED_ID
+
+        if (
+            "/.git/config" in path_lower
+            or "/.git/head" in path_lower
+        ):
+            if "/.git/head" in path_lower:
+                body = self._git_head()
+            else:
+                body = self._git_config()
+            return self._build_http_response(
+                body, 200, "OK", {"Content-Type": "text/plain"}
+            ), self.DETECTED_ID
+
+        if "/security.txt" in path_lower or "/.well-known/security.txt" in path_lower:
+            body = self._security_txt()
+            return self._build_http_response(
+                body, 200, "OK", {"Content-Type": "text/plain"}
+            ), self.DETECTED_ID
+
 
         # Default: serve wp-config.php as the most common target
         body = self._wp_config_php()
@@ -1389,6 +1413,48 @@ INSERT INTO `api_keys` VALUES (2,2,'ak_test_abcdef1234567890','sk_test_fedcba098
 <address>Apache/2.4.57 (Ubuntu) Server at example.com Port 80</address>
 </body>
 </html>"""
+
+    def _git_config(self) -> str:
+        """Fake .git/config file with realistic remote URLs."""
+        return r"""[core]
+	repositoryformatversion = 0
+	filemode = true
+	bare = false
+	logallrefupdates = true
+	precomposeUnicode = true
+[remote "origin"]
+	url = git@github.com:company/myapp.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+[branch "main"]
+	remote = origin
+	merge = refs/heads/main
+[branch "develop"]
+	remote = origin
+	merge = refs/heads/develop
+[user]
+	name = Developer
+	email = dev@company.com
+[credential]
+	helper = store
+[http]
+	sslVerify = false
+"""
+
+    def _git_head(self) -> str:
+        """Fake .git/HEAD file."""
+        return r"ref: refs/heads/main" + "\n"
+
+    def _security_txt(self) -> str:
+        """Fake security.txt following RFC 9116."""
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        return f"""Contact: mailto:security@example.com
+Contact: https://example.com/.well-known/security.txt
+Expires: {now}T23:59:59Z
+Encryption: https://example.com/pgp-key.txt
+Preferred-Languages: en, es, zh
+Hiring: https://example.com/careers
+Policy: https://example.com/security-policy
+"""
 
     def _extract_method(self, raw_request: str) -> str:
         """Extract HTTP method from raw request."""

--- a/manyfaced/handlers/http_handler.py
+++ b/manyfaced/handlers/http_handler.py
@@ -25,6 +25,7 @@ from manyfaced.common.logging_setup import get_logger
 from manyfaced.common.protocol import detect_protocol, get_protocol_info
 from manyfaced.common.status import SSH_CLIENT, UNKNOWN_NON_HTTP
 
+from .config_disclosure_handler import ConfigDisclosureHandler
 from .cpanel_handler import CPanelHandler
 from .drupal_handler import DrupalHandler
 from .generic_handler import GenericHandler
@@ -118,6 +119,8 @@ def _get_registry() -> HandlerRegistry:
         _registry.register(TomcatHandler())
         _registry.register(DrupalHandler())
         _registry.register(CPanelHandler())
+        # Config disclosure handler – catches config file probes before generic fallback
+        _registry.register(ConfigDisclosureHandler())
         # Generic handler is last – catches everything else
         _registry.register(GenericHandler())
         logger.info(

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -539,6 +539,58 @@ class TestConfigDisclosureHandler(unittest.TestCase):
         self.assertIn(b"XML-RPC", response)
 
 
+    def test_git_config(self):
+        profile = MagicMock()
+        self.handler.bot_profiles = {"1.2.3.4": profile}
+        response, _ = self.handler.generate_response(
+            "/.git/config",
+            "GET /.git/config HTTP/1.1\r\nHost: example.com\r\n\r\n",
+            "1.2.3.4",
+        )
+        self.assertIn(b'[remote "origin"]', response)
+        self.assertIn(b"git@github.com", response)
+        self.assertIn(b"company/myapp", response)
+
+    def test_git_head(self):
+        profile = MagicMock()
+        self.handler.bot_profiles = {"1.2.3.4": profile}
+        response, _ = self.handler.generate_response(
+            "/.git/HEAD",
+            "GET /.git/HEAD HTTP/1.1\r\nHost: example.com\r\n\r\n",
+            "1.2.3.4",
+        )
+        self.assertIn(b"ref: refs/heads/main", response)
+
+    def test_security_txt(self):
+        profile = MagicMock()
+        self.handler.bot_profiles = {"1.2.3.4": profile}
+        response, _ = self.handler.generate_response(
+            "/security.txt",
+            "GET /security.txt HTTP/1.1\r\nHost: example.com\r\n\r\n",
+            "1.2.3.4",
+        )
+        self.assertIn(b"Contact:", response)
+        self.assertIn(b"mailto:security@example.com", response)
+        self.assertIn(b"Expires:", response)
+
+    def test_well_known_security_txt(self):
+        profile = MagicMock()
+        self.handler.bot_profiles = {"1.2.3.4": profile}
+        response, _ = self.handler.generate_response(
+            "/.well-known/security.txt",
+            "GET /.well-known/security.txt HTTP/1.1\r\nHost: example.com\r\n\r\n",
+            "1.2.3.4",
+        )
+        self.assertIn(b"Contact:", response)
+        self.assertIn(b"mailto:security@example.com", response)
+
+    def test_matches_git_and_security_paths(self):
+        self.assertTrue(self.handler.matches_path("/.git/config"))
+        self.assertTrue(self.handler.matches_path("/.git/HEAD"))
+        self.assertTrue(self.handler.matches_path("/.git/index"))
+        self.assertTrue(self.handler.matches_path("/security.txt"))
+        self.assertTrue(self.handler.matches_path("/.well-known/security.txt"))
+
 class TestCPanelHandler(unittest.TestCase):
     """Test CPanelHandler responses."""
 
@@ -610,6 +662,7 @@ class TestHandlerRegistry(unittest.TestCase):
         self.registry.register(TomcatHandler())
         self.registry.register(DrupalHandler())
         self.registry.register(CPanelHandler())
+        self.registry.register(ConfigDisclosureHandler())
         self.registry.register(GenericHandler())
 
     def test_get_handler_wordpress(self):
@@ -652,11 +705,11 @@ class TestHandlerRegistry(unittest.TestCase):
 
     def test_get_all_handlers(self):
         handlers = self.registry.get_all_handlers()
-        self.assertEqual(len(handlers), 7)
+        self.assertEqual(len(handlers), 8)
 
     def test_stats(self):
         stats = self.registry.get_stats()
-        self.assertEqual(stats["total_handlers"], 7)
+        self.assertEqual(stats["total_handlers"], 8)
         self.assertIn("handlers", stats)
 
     def test_get_all_matching_handlers(self):

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -538,7 +538,6 @@ class TestConfigDisclosureHandler(unittest.TestCase):
         )
         self.assertIn(b"XML-RPC", response)
 
-
     def test_git_config(self):
         profile = MagicMock()
         self.handler.bot_profiles = {"1.2.3.4": profile}
@@ -590,6 +589,7 @@ class TestConfigDisclosureHandler(unittest.TestCase):
         self.assertTrue(self.handler.matches_path("/.git/index"))
         self.assertTrue(self.handler.matches_path("/security.txt"))
         self.assertTrue(self.handler.matches_path("/.well-known/security.txt"))
+
 
 class TestCPanelHandler(unittest.TestCase):
     """Test CPanelHandler responses."""


### PR DESCRIPTION
## Changes

### New Response Methods in ConfigDisclosureHandler
- **`.git/config`** — Serves a realistic fake Git config with remote URLs (git@github.com), branch refs, and credential helper settings
- **`.git/HEAD`** — Returns `ref: refs/heads/main` mimicking a standard Git repository HEAD file
- **`security.txt`** / **`.well-known/security.txt`** — Serves an RFC 9116 compliant security.txt with contact email, encryption key URL, policy link, and expiry date

### Registration
- ConfigDisclosureHandler is now registered in the HTTP handler dispatcher (`http_handler.py`) before the GenericHandler fallback

### Tests
- Added `test_git_config()`, `test_git_head()`, `test_security_txt()`, `test_well_known_security_txt()`, `test_matches_git_and_security_paths()`
- Updated `TestHandlerRegistry` to include ConfigDisclosureHandler (8 handlers total)

All 77 tests pass.