### PR TITLE
fix: replace fragile ss regex health check with per-port filter checks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -172,17 +172,69 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Health check: verify honeypot is actually listening on configured ports.
-          # Reads HONEY_TOP_PORTS from the droplet's own env file (source of truth).
-          ssh -p "${DROPLET_SSH_PORT}" "${DROPLET_SSH_USER}@${DROPLET_SERVER_IP}" "
-            PORTS=\$(grep '^HONEY_TOP_PORTS=' /opt/manyfaced/honeypot.env 2>/dev/null | cut -d= -f2) && \
-            if [ -z \"\$PORTS\" ]; then echo 'ERROR: HONEY_TOP_PORTS not found in honeypot.env'; exit 1; fi && \
-            LISTENING=\$(ss -tlnp 2>/dev/null | grep -oP '(?<=:)\\d+(?= )' | sort -u) && \
-            MISSING=0 && \
-            for p in \$(echo \$PORTS | tr ',' '\\n'); do echo \"\$LISTENING\" | grep -q \"^\$p\$\" || { echo \"Port \$p NOT listening\"; MISSING=\$((MISSING+1)); }; done && \
-            if [ \$MISSING -gt 0 ]; then echo \"FAIL: \$MISSING of \$PORTS ports not listening\"; exit 1; fi && \
-            echo 'Health check OK: honeypot listening on all configured ports'"
+          # Health check: verify every port in HONEY_TOP_PORTS is in LISTEN state.
+          # Uses per-port ss filter syntax (sport = :PORT) — no regex over ss output.
+          # Expands ranges (e.g. 11300-11311 → individual ports). Retries up to
+          # 10 times with 3s sleep for a total 30-second budget on startup.
+          ssh -p "${DROPLET_SSH_PORT}" "${DROPLET_SSH_USER}@${DROPLET_SERVER_IP}" 'bash -c '"'"'
+            set -euo pipefail
 
+            # Read HONEY_TOP_PORTS from the droplet env file (source of truth)
+            PORTS_RAW=$(grep "^HONEY_TOP_PORTS=" /opt/manyfaced/honeypot.env 2>/dev/null | cut -d= -f2)
+            if [ -z "$PORTS_RAW" ]; then echo "ERROR: HONEY_TOP_PORTS not found in honeypot.env"; exit 1; fi
+
+            # Expand port list: split on commas, expand ranges via seq, validate tokens
+            PORT_LIST=""
+            for token in $(echo "$PORTS_RAW" | tr "," "\n"); do
+              if echo "$token" | grep -qP "^[0-9]+-[0-9]+$"; then
+                # Range like 11300-11311 → expand to individual ports
+                PORT_LIST="$PORT_LIST $(seq $token)"
+              elif echo "$token" | grep -qP "^[0-9]+$"; then
+                # Single port — keep as-is
+                PORT_LIST="$PORT_LIST $token"
+              else
+                echo "ERROR: malformed port token \"$token\" in HONEY_TOP_PORTS"
+                exit 1
+              fi
+            done
+
+            # Normalize to one-port-per-line, strip blanks
+            PORT_LIST=$(echo "$PORT_LIST" | tr -s " \t\n" "\n" | grep -v "^$")
+            TOTAL=$(echo "$PORT_LIST" | wc -l)
+
+            echo "Checking $TOTAL ports from HONEY_TOP_PORTS ..."
+
+            # Retry loop: up to 10 iterations × 3 s = 30 s budget
+            MAX_RETRIES=10
+            for (( i=1; i<=MAX_RETRIES; i++ )); do
+              MISSING=""
+              while read -r p; do
+                if ! ss -Htln "sport = :$p" | grep -q LISTEN; then
+                  MISSING="$MISSING $p"
+                fi
+              done <<< "$PORT_LIST"
+
+              # Trim leading space
+              MISSING="${MISSING# }"
+
+              if [ -z "$MISSING" ]; then
+                echo "Health check OK: $TOTAL/$TOTAL ports listening"
+                exit 0
+              fi
+
+              if [ "$i" -lt "$MAX_RETRIES" ]; then
+                MISSING_COUNT=$(echo "$MISSING" | wc -w)
+                echo "Iteration $i: $MISSING_COUNT port(s) not yet listening, retrying ..."
+                sleep 3
+              else
+                echo "FAIL: ports never reached LISTEN state after $MAX_RETRIES attempts:"
+                while read -r p; do
+                  echo "  MISSING: $p"
+                done <<< "$MISSING"
+                exit 1
+              fi
+            done
+          '"'"''
       - name: Clean up old releases (keep last 5)
         env:
           DROPLET_SSH_PORT: ${{ secrets.DROPLET_SSH_PORT }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ See `DEVELOPER.md` section "How to Add New Faces" for the full procedure:
 
 ## Deployment
 
-After squash-merging to `master`, the deploy workflow runs automatically (CI must pass first). The deploy workflow rsyncs the commit to `/opt/manyfaced/releases/<sha>/`, installs deps into the shared venv, atomically flips `/opt/manyfaced/current` via rename(2), and restarts the systemd service. Rollback flips the symlink back to the previous release. Check the GitHub Actions tab for deployment status. The `honeypot.env` file (port config) lives only on the droplet and is not version-controlled.
+After squash-merging to `master`, the deploy workflow runs automatically (CI must pass first). The deploy workflow rsyncs the commit to `/opt/manyfaced/releases/<sha>/`, installs deps into the shared venv, atomically flips `/opt/manyfaced/current` via rename(2), and restarts the systemd service. Post-restart, the workflow verifies every port in `HONEY_TOP_PORTS` is in LISTEN state (with a 30-second retry budget for startup). Rollback flips the symlink back to the previous release. Check the GitHub Actions tab for deployment status. The `honeypot.env` file (port config) lives only on the droplet and is not version-controlled.
 
 ## What not to do
 


### PR DESCRIPTION
## Summary

Replaces the deploy.yml health-check step with a robust **per-port `ss` filter** approach. The previous implementation used a fragile regex over `ss -tlnp` output and had three bugs:

### Bugs fixed

1. **Port ranges silently skipped**: `HONEY_TOP_PORTS` can contain range tokens like `11300-11311`. The old loop treated them as single literal strings, never matching individual ports. 12 ports were unverified on every deploy.
2. **No retry budget**: The check ran once after a 3-second sleep. If any of the ~57 honeypot ports hadn't bound yet, the deploy failed for a transient reason.
3. **Unreadable failure message**: Printed `FAIL: N of <full-port-list> ports not listening` — impossible to parse which ports were missing.

### What changed

- **Per-port `ss` filter checks**: Uses `ss -Htln "sport = :PORT"` for each port individually, instead of regex over the entire `ss` output. This doesn't depend on the shape of `ss` output and won't break with future changes.
- **Range expansion**: Splits `HONEY_TOP_PORTS` on commas, expands ranges via `seq`, validates every token against `^[0-9]+$` or `^[0-9]+-[0-9]+$`. Malformed tokens cause a loud failure instead of silent skip.
- **Bounded retry loop**: 10 iterations × 3-second sleep = 30-second budget for startup. Exits early on success (healthy deploys won't consume the full budget). Progress lines show iteration count and missing port count.
- **Clear failure output**: On exhaustion, prints each missing port on its own line prefixed with `MISSING:`.

### Files changed

- `.github/workflows/deploy.yml` — health-check step rewritten (lines 167–237)
- `CONTRIBUTING.md` — added one sentence to the Deployment section documenting the post-restart health check

### Acceptance criteria

| Criterion | Status |
|-----------|--------|
| No `grep -oP` in health-check step | ✅ |
| No `LISTENING=` in health-check step | ✅ |
| Per-port `ss -Htln "sport = :PORT"` checks | ✅ |
| Range expansion via `seq` | ✅ |
| Retry budget: 10 × 3s = 30s | ✅ |
| Early exit on success | ✅ |
| Success message: `Health check OK: N/N ports listening` | ✅ |
| Failure prints missing ports one per line with prefix | ✅ |
| `set -euo pipefail` preserved | ✅ |
| CONTRIBUTING.md updated | ✅ |