### PR TITLE
chore: add actionlint to CI workflow checks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,8 +95,17 @@ jobs:
       - name: Type check with basedpyright
         run: basedpyright manyfaced/
 
+  actionlint:
+    name: Lint GitHub Actions workflows
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run actionlint
+        uses: raven-actions/actionlint@v2
+
   deploy:
-    needs: [lint, test, typecheck]
+    needs: [lint, test, typecheck, actionlint]
     # Only deploy on push-to-master and manual dispatch; skip on PRs.
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
@@ -113,7 +122,7 @@ jobs:
         run: |
           set -euo pipefail
           SHORT_SHA=$(git rev-parse --short=12 HEAD)
-          echo "short_sha=${SHORT_SHA}" >> $GITHUB_OUTPUT
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
           echo "Deploying short SHA: ${SHORT_SHA}"
 
       - name: Set up SSH

--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ report-*.md
 
 # Production backups
 prod-backup/
+
+# Local CLI binaries (downloaded for local pre-checks)
+actionlint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 1. **Branch off latest `master`.** Use a descriptive name: `feature/add-jenkins-face`, `fix/ua-extraction-bug`.
 2. **Commit in small, logically-grouped chunks.** Imperative mood subject line (~72 chars). Add a body when the "why" isn't obvious from the diff. Don't pre-squash locally — let squash-merge handle it.
-3. **Open a PR against `master`.** Opening triggers CI (ruff lint on 3.14 + pytest and basedpyright on Python 3.12, 3.13, 3.14).
+3. **Open a PR against `master`.** Opening triggers CI (ruff lint on 3.14 + pytest and basedpyright on Python 3.12, 3.13, 3.14 + actionlint on workflow files).
 4. **Watch CI.** Fix failures by fixing the underlying problem, not by disabling checks. If a failure is unrelated to your change, say so explicitly in PR comments.
 5. **Squash-merge once green.** No regular merges — keep `master` linear.
 6. **Verify post-merge deployment.** The deploy workflow runs automatically on push to master (after CI passes). Link the Actions run URL in a final PR comment. If no deploy workflow is configured, document that gap here.
@@ -34,6 +34,7 @@ Style rules are enforced by tooling, not prose. The authoritative configs are:
 - **Lint + format:** `pyproject.toml` → `[tool.ruff]`
 - **Editor defaults:** `.editorconfig` (UTF-8, LF, 4-space indent for Python)
 - **Pre-commit hook:** `.pre-commit-config.yaml` (runs ruff on staged files)
+- **GitHub Actions workflows:** linted with actionlint (`brew install actionlint` or `go install github.com/rhysd/actionlint/cmd/actionlint@latest`). Run locally: `./actionlint .github/workflows/`. CI runs it on every push.
 
 Run `ruff check . && ruff format .` before committing. The CI job will reject anything that doesn't pass.
 


### PR DESCRIPTION
## Summary

Adds **actionlint** as a CI job that lints all GitHub Actions workflows. This catches the class of bugs we spent three PRs (Briefs 1-3) fixing - broken regexes, missing `set -euo pipefail`, masked pip errors, expression syntax issues.

## Changes

### `.github/workflows/deploy.yml`
- Added new `actionlint` job running in parallel with `lint`, `test`, and `typecheck` (no `needs:` dependency)
- Uses `raven-actions/actionlint@v2` (version-pinned, no manual setup needed)
- Updated `deploy` job's `needs:` from `[lint, test, typecheck]` to `[lint, test, typecheck, actionlint]` - a workflow lint failure now blocks deploys

### `.github/workflows/deploy.yml` (pre-existing fix)
- Fixed SC2086 shellcheck warning: quoted `$GITHUB_OUTPUT` in the "Resolve commit SHA" step (`>> "$GITHUB_OUTPUT"`). This was caught by actionlint's built-in shellcheck integration.

### `CONTRIBUTING.md`
- Added actionlint bullet under "Code style" section with install instructions and local run command
- Updated step 3 in "The shipping loop" to mention actionlint as part of CI checks

### `.gitignore`
- Added `actionlint` binary (local pre-check tool, not committed)

## Pre-existing findings

| Finding | Decision |
|---------|----------|
| SC2086: unquoted `$GITHUB_OUTPUT` in "Resolve commit SHA" step | **Fixed** - added double quotes. Legitimate shellcheck fix. |

No other actionlint findings on existing workflow files.

## Acceptance criteria

- ✅ `actionlint` job exists at the same level as other CI jobs
- ✅ `deploy` job's `needs:` includes `actionlint`
- ✅ On PR: `actionlint` and `ci` (lint+test+typecheck) run; `deploy` is skipped
- ✅ Actionlint passes on current workflow files
- ✅ Action used is pinned to `@v2`, not `@main` or `@latest`
- ✅ Pre-existing actionlint finding fixed in this PR