### PR TITLE
fix(client): use HIVELOGIN as sensor ID for server auth

### DIFF
--- a/manyfaced/client/client.py
+++ b/manyfaced/client/client.py
@@ -221,15 +221,17 @@ REPORT_SEND_RETRY_DELAY = 2  # seconds
 REPORT_SEND_BACKOFF_FACTOR = 2  # exponential backoff
 
 
-def send_report(data, client, password, server_host, server_port):
+def send_report(data, client, password, server_host, server_port, sensor_id=None):
     """Send a bot report to the server as an encrypted TCP message.
 
     Args:
         data: BearStorage instance with bot data
-        client: Bot IP address
+        client: Bot IP address (used for logging and data dict)
         password: AES encryption password (HIVEPASS)
         server_host: Server hostname
         server_port: Server port number
+        sensor_id: Sensor identifier sent as message prefix to the server.
+                   If None, falls back to client IP (legacy behavior).
     """
     cypher = AESCipher(password)
     parsed = data.parsed_request if hasattr(data, 'parsed_request') else None
@@ -266,7 +268,8 @@ def send_report(data, client, password, server_host, server_port):
         'country': getattr(data, 'country', '') or '',
         'continent': getattr(data, 'continent', '') or '',
     }
-    message = (client + ':').encode()
+    identifier = sensor_id if sensor_id else client
+    message = (identifier + ':').encode()
     message += cypher.encrypt(json.dumps(data_dict).encode()).encode()
 
     # Retry with exponential backoff to handle server restarts

--- a/manyfaced/handlers/http_handler.py
+++ b/manyfaced/handlers/http_handler.py
@@ -250,7 +250,12 @@ class HTTPHandler:
             logger.debug('Geo resolution failed for %s', bot_ip)
 
         q = _get_report_queue()
-        q.put((send_report, (bs, bot_ip, settings.HIVEPASS, server_host, server_port)))
+        q.put(
+            (
+                send_report,
+                (bs, bot_ip, settings.HIVEPASS, server_host, server_port, settings.HIVELOGIN),
+            )
+        )
 
     def _handle_ssh_probe(self, bot_ip: str, protocol_info: dict) -> bytes:
         """Handle an SSH probe by responding with a fake SSH banner and capturing credentials.


### PR DESCRIPTION
## Problem

The client was sending the **bot IP** as the message prefix identifier when submitting reports to the server. But the server's `get_key()` method looks up this identifier in `AUTHORIZED_BEES` to find the decryption key. Since no authorized bees were configured, every report submission was rejected with:

```
ERROR | Unexpected error: Unknown identifier 'X.X.X.X' – not authorized
```

This meant **zero data was being persisted** after service restarts — the honeypot captured interactions live but couldn't save them.

## Fix

Change the client to send a **sensor identifier** (from `[hive]hivelogin`) instead of the bot IP as the message prefix. The sensor ID is passed from `http_handler.py:_send_report()` via `settings.HIVELOGIN`.

## Changes

- **client.py**: Added `sensor_id` parameter to `send_report()`, uses it for message prefix
- **http_handler.py**: Passes `settings.HIVELOGIN` as sensor_id when queuing reports

## Testing

All 341 tests pass (74% coverage).

## Production Note

After deploying this code, the production server config also needs `authorized_bees` populated with the HIVELOGIN identifier and matching key.