### PR TITLE
fix(http_handler): also use HIVELOGIN as sensor ID in process_request()

### DIFF
--- a/manyfaced/handlers/http_handler.py
+++ b/manyfaced/handlers/http_handler.py
@@ -476,7 +476,12 @@ class HTTPHandler:
             # per bot request (200+ processes logged), causing file descriptor
             # exhaustion and crashes. Worker threads pull from the queue.
             q = _get_report_queue()
-            q.put((send_report, (bs, bot_ip, settings.HIVEPASS, server_host, server_port)))
+            q.put(
+                (
+                    send_report,
+                    (bs, bot_ip, settings.HIVEPASS, server_host, server_port, settings.HIVELOGIN),
+                )
+            )
         else:
             logger.debug('No server port configured, skipping report for %s', bot_ip)
 


### PR DESCRIPTION
## Problem

PR #64 added `sensor_id` support to `send_report()` and updated `_send_report()`, but missed a second call site in `process_request()`. This method handles the main HTTP request path and still sends bot IP as the identifier.

As a result, most reports (HTTP requests) were still being rejected with:
```
ERROR | Unexpected error: Unknown identifier 'X.X.X.X' – not authorized
```

## Fix

Update `process_request()` to also pass `settings.HIVELOGIN` as sensor_id when queuing reports.

## Changes

- **http_handler.py**: Updated `q.put()` in `process_request()` (line 479) to include `settings.HIVELOGIN` as the sixth argument

## Testing

All 341 tests pass (74% coverage).