### PR TITLE
fix: storage backend reads DB path from TOML config, not just env var

### DIFF
--- a/manyfaced/db/storage.py
+++ b/manyfaced/db/storage.py
@@ -63,8 +63,28 @@ _PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '.
 
 
 def _resolve_db_path() -> str:
-    """Return the SQLite database path from env or default."""
-    return os.environ.get('HONEY_DB_PATH', 'bots/honeypot.sqlite')
+    """Return the SQLite database path.
+
+    Precedence (highest to lowest):
+      1. HONEY_DB_PATH environment variable
+      2. database.path from TOML config (settings.DB_PATH)
+      3. Default 'bots/honeypot.sqlite' (relative to CWD)
+    """
+    env_path = os.environ.get('HONEY_DB_PATH')
+    if env_path:
+        return env_path
+
+    # Fall back to TOML config setting
+    try:
+        from manyfaced.common.config import settings  # noqa: PLC0415
+
+        toml_path = getattr(settings, 'DB_PATH', None)
+        if toml_path:
+            return toml_path
+    except Exception:
+        pass
+
+    return 'bots/honeypot.sqlite'
 
 
 def _resolve_backend() -> str:

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -25,6 +25,10 @@ sys.modules['geoip.geolite2'] = MagicMock()
 sys.modules['GeoIP'] = MagicMock()
 
 
+# --- Resolve DB path for tests (must match what storage.py resolves) ---
+from manyfaced.db.storage import _resolve_db_path  # noqa: E402
+
+
 # --- Test key shared between encryptor and ServerHandler ---
 TEST_KEY = 'beehive123'
 BEE_IDENTIFIER = 'testbee'
@@ -48,7 +52,9 @@ def make_encrypted_message(identifier: str, data: dict, key: str) -> str:  # noq
 @pytest.fixture(autouse=True)
 def _clean_env_and_db():
     """Ensure clean DB and settings for every test."""
-    db_path = 'bots/honeypot.sqlite'
+    from manyfaced.db.storage import _resolve_db_path  # noqa: E402
+
+    db_path = _resolve_db_path()
     if Path(db_path).exists():
         Path(db_path).unlink(missing_ok=True)
     yield
@@ -158,7 +164,7 @@ class TestFullPathSocketToDatabase:
 
         _ = self._run_pipeline(bear_data)
 
-        _verify_record('bots/honeypot.sqlite', ip='10.1.2.3', path='/wp-login.php', detected=1)
+        _verify_record(_resolve_db_path(), ip='10.1.2.3', path='/wp-login.php', detected=1)
 
     def test_detects_webdav_scan_and_saves_to_sqlite(self):
         """A WebDAV PROPFIND-style scan should be detected and stored."""
@@ -184,7 +190,7 @@ class TestFullPathSocketToDatabase:
         _ = self._run_pipeline(bear_data)
 
         _verify_record(
-            'bots/honeypot.sqlite',
+            _resolve_db_path(),
             ip='192.168.99.99',
             path='/webdav/',
             field='request_command',
@@ -209,7 +215,7 @@ class TestFullPathSocketToDatabase:
         # Verify nothing was saved to the DB
         import sqlite3
 
-        conn = sqlite3.connect('bots/honeypot.sqlite')
+        conn = sqlite3.connect(_resolve_db_path())
         # Table may not exist if no valid request was processed yet
         tables = conn.execute(
             "SELECT name FROM sqlite_master WHERE type='table' AND name='honeypot_bears'"
@@ -262,13 +268,13 @@ class TestFullPathSocketToDatabase:
         # Verify all 3 records exist
         import sqlite3
 
-        conn = sqlite3.connect('bots/honeypot.sqlite')
+        conn = sqlite3.connect(_resolve_db_path())
         count = conn.execute('SELECT COUNT(*) FROM honeypot_bears').fetchone()[0]
         conn.close()
         assert count == 3
 
         # Verify specific IPs exist
-        conn = sqlite3.connect('bots/honeypot.sqlite')
+        conn = sqlite3.connect(_resolve_db_path())
         ips = [r[0] for r in conn.execute('SELECT bot_ip FROM honeypot_bears').fetchall()]
         conn.close()
         assert '10.10.10.0' in ips
@@ -290,7 +296,7 @@ class TestFullPathSocketToDatabase:
         _ = self._run_pipeline(bear_data)
 
         _verify_record(
-            'bots/honeypot.sqlite',
+            _resolve_db_path(),
             ip='172.16.0.1',
             path='/wp-content/debug.log',
             field='request_raw',
@@ -310,7 +316,7 @@ class TestFullPathSocketToDatabase:
 
         _ = self._run_pipeline(bear_data)
 
-        _verify_record('bots/honeypot.sqlite', field='login', value='testuser123')
+        _verify_record(_resolve_db_path(), field='login', value='testuser123')
 
     def test_detected_field_preserved(self):
         """is_detected should store the correct value in detected_id."""
@@ -328,7 +334,7 @@ class TestFullPathSocketToDatabase:
         _ = self._run_pipeline(bear_data)
 
         _verify_record(
-            'bots/honeypot.sqlite',
+            _resolve_db_path(),
             ip='10.10.10.20',
             path='/unknown',
             detected=UNKNOWN_HTTP,

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -35,22 +35,28 @@ class TestResolveDbPath:
     """Tests for _resolve_db_path()."""
 
     def test_default_path_when_env_not_set(self):
-        with patch.dict(os.environ, {}, clear=True), \
-             patch('manyfaced.common.config.settings', DB_PATH=None):
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch('manyfaced.common.config.settings', DB_PATH=None),
+        ):
             result = _resolve_db_path()
         assert result == 'bots/honeypot.sqlite'
 
     def test_falls_back_to_toml_config_db_path(self):
         """When no env var is set, falls back to TOML config's database.path."""
-        with patch.dict(os.environ, {}, clear=True), \
-             patch('manyfaced.common.config.settings', DB_PATH='/custom/from/toml.db'):
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch('manyfaced.common.config.settings', DB_PATH='/custom/from/toml.db'),
+        ):
             result = _resolve_db_path()
         assert result == '/custom/from/toml.db'
 
     def test_env_overrides_toml_config(self):
         """HONEY_DB_PATH env var takes precedence over TOML config."""
-        with patch.dict(os.environ, {'HONEY_DB_PATH': '/env/override.db'}, clear=True), \
-             patch('manyfaced.common.config.settings', DB_PATH='/toml/path.db'):
+        with (
+            patch.dict(os.environ, {'HONEY_DB_PATH': '/env/override.db'}, clear=True),
+            patch('manyfaced.common.config.settings', DB_PATH='/toml/path.db'),
+        ):
             result = _resolve_db_path()
         assert result == '/env/override.db'
 

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -35,9 +35,24 @@ class TestResolveDbPath:
     """Tests for _resolve_db_path()."""
 
     def test_default_path_when_env_not_set(self):
-        with patch.dict(os.environ, {}, clear=True):
+        with patch.dict(os.environ, {}, clear=True), \
+             patch('manyfaced.common.config.settings', DB_PATH=None):
             result = _resolve_db_path()
         assert result == 'bots/honeypot.sqlite'
+
+    def test_falls_back_to_toml_config_db_path(self):
+        """When no env var is set, falls back to TOML config's database.path."""
+        with patch.dict(os.environ, {}, clear=True), \
+             patch('manyfaced.common.config.settings', DB_PATH='/custom/from/toml.db'):
+            result = _resolve_db_path()
+        assert result == '/custom/from/toml.db'
+
+    def test_env_overrides_toml_config(self):
+        """HONEY_DB_PATH env var takes precedence over TOML config."""
+        with patch.dict(os.environ, {'HONEY_DB_PATH': '/env/override.db'}, clear=True), \
+             patch('manyfaced.common.config.settings', DB_PATH='/toml/path.db'):
+            result = _resolve_db_path()
+        assert result == '/env/override.db'
 
     def test_custom_path_from_env(self):
         with patch.dict(os.environ, {'HONEY_DB_PATH': '/tmp/custom.db'}, clear=True):


### PR DESCRIPTION
## Problem

The SQLite storage backend's `_resolve_db_path()` only checked the `HONEY_DB_PATH` environment variable and defaulted to `'bots/honeypot.sqlite'`. It completely ignored the `database.path` setting in the TOML config file.

This caused data to be written to a release-relative path (e.g. `/opt/manyfaced/current/bots/honeypot.sqlite`) instead of the configured persistent path (`/opt/manyfaced/bots/honeypot.sqlite`), meaning all bot data was lost on every deployment.

## Fix

`_resolve_db_path()` now checks in order:
1. `HONEY_DB_PATH` env var (highest priority)
2. `settings.DB_PATH` from TOML config
3. Default `'bots/honeypot.sqlite'`

## Tests

- Updated `test_storage.py`: added tests for TOML fallback and env-overrides-TOML precedence
- Updated `test_integration.py`: all DB path references now use `_resolve_db_path()` instead of hardcoded paths
- All 343 tests pass (74% coverage)