### PR TITLE
fix: complete HTTP enrichment pipeline (server-side drop + hostname key mismatch)

### DIFF
--- a/manyfaced/common/bearstorage.py
+++ b/manyfaced/common/bearstorage.py
@@ -91,7 +91,7 @@ class BearStorage:
             self.continent = continent
             return (country, continent)
         except Exception as e:
-            logger.debug('Geo resolution failed for %s: %s', ip, e)
+            logger.warning('Geo resolution failed for %s: %s', ip, e)
             return ('', '')
 
     def __str__(self) -> str:

--- a/manyfaced/common/geolocate.py
+++ b/manyfaced/common/geolocate.py
@@ -70,7 +70,7 @@ def lookup_ip_geolocation(ip: str, timeout: float = 2.0) -> tuple[str, str]:
             return (country, continent)
 
     except Exception as e:
-        logger.debug('Geo lookup failed for %s: %s', ip, e)
+        logger.warning('Geo lookup failed for %s: %s', ip, e)
 
     # On failure, cache empty result to avoid repeated lookups
     _geo_cache[ip] = {'country': '', 'continent': ''}

--- a/manyfaced/db/dbconnect.py
+++ b/manyfaced/db/dbconnect.py
@@ -20,6 +20,10 @@ class BearRequests:
     parsed_request: dict[str, Any]
     is_detected: int
     HIVELOGIN: str
+    ua: str = ''
+    dns_name: str = ''
+    country: str = ''
+    continent: str = ''
 
 
 def Insert(bear: BearRequests) -> None:
@@ -32,5 +36,9 @@ def Insert(bear: BearRequests) -> None:
         'parsed_request': bear.parsed_request,
         'is_detected': bear.is_detected,
         'HIVELOGIN': bear.HIVELOGIN,
+        'ua': bear.ua,
+        'dns_name': bear.dns_name,
+        'country': bear.country,
+        'continent': bear.continent,
     }
     storage.insert(record)

--- a/manyfaced/db/storage.py
+++ b/manyfaced/db/storage.py
@@ -164,7 +164,7 @@ class SQLiteStorage(StorageBackend):
             parsed = record.get('parsed_request') or {}
 
             bot_ip = record.get('ip') or ''
-            hostname = record.get('hostname') or ''
+            hostname = record.get('hostname') or record.get('HIVELOGIN') or ''
             timestamp = record.get('timestamp') or ''
             request_path = parsed.get('path') or record.get('request_path') or ''
             request_command = parsed.get('command') or record.get('request_command') or ''
@@ -328,7 +328,7 @@ class PostgreSQLStorage(StorageBackend):
             parsed = record.get('parsed_request') or {}
 
             bot_ip = record.get('ip') or ''
-            hostname = record.get('hostname') or ''
+            hostname = record.get('hostname') or record.get('HIVELOGIN') or ''
             timestamp = record.get('timestamp') or ''
             request_path = parsed.get('path') or record.get('request_path') or ''
             request_command = parsed.get('command') or record.get('request_command') or ''

--- a/manyfaced/server/server.py
+++ b/manyfaced/server/server.py
@@ -55,7 +55,11 @@ class ServerHandler(BaseHandler):
                 timestamp=data['timestamp'],
                 parsed_request=data['parsed_request'],
                 is_detected=data['is_detected'],
-                HIVELOGIN=data['HIVELOGIN'],
+                HIVELOGIN=data.get('HIVELOGIN', ''),
+                ua=data.get('ua', ''),
+                dns_name=data.get('dns_name', ''),
+                country=data.get('country', ''),
+                continent=data.get('continent', ''),
             )
             Insert(bear)
             logger.info('Data saved for %s', data['ip'])

--- a/test/test_dbconnect.py
+++ b/test/test_dbconnect.py
@@ -39,6 +39,30 @@ class TestBearRequestsCreation:
         assert bear.parsed_request == {'path': '/admin', 'command': 'GET'}
         assert bear.is_detected == 1
         assert bear.HIVELOGIN == 'admin'
+        # Enrichment fields default to ''
+        assert bear.ua == ''
+        assert bear.dns_name == ''
+        assert bear.country == ''
+        assert bear.continent == ''
+
+    def test_create_with_enrichment_fields(self):
+        """BearRequests should carry enrichment data from the client payload."""
+        bear = BearRequests(
+            ip='1.2.3.4',
+            raw_request='GET /admin HTTP/1.1',
+            timestamp='2024-01-15 10:30:00',
+            parsed_request={'path': '/admin', 'command': 'GET'},
+            is_detected=1,
+            HIVELOGIN='admin',
+            ua='Mozilla/5.0 (compatible; bot)',
+            dns_name='scan.example.com',
+            country='Russia',
+            continent='Europe',
+        )
+        assert bear.ua == 'Mozilla/5.0 (compatible; bot)'
+        assert bear.dns_name == 'scan.example.com'
+        assert bear.country == 'Russia'
+        assert bear.continent == 'Europe'
 
     def test_create_with_empty_fields(self):
         bear = BearRequests(
@@ -109,6 +133,10 @@ class TestBearRequestsDataclassRepr:
             'parsed_request',
             'is_detected',
             'HIVELOGIN',
+            'ua',
+            'dns_name',
+            'country',
+            'continent',
         ]
 
     def test_dataclass_repr(self):
@@ -306,7 +334,7 @@ class TestInsertFunction:
             mock_get.assert_called_once()
 
     def test_insert_record_has_all_keys(self):
-        """The record dict passed to storage.insert() must contain all 6 keys."""
+        """The record dict passed to storage.insert() must contain all 10 keys."""
         mock_storage = MagicMock()
 
         bear = BearRequests(
@@ -329,5 +357,57 @@ class TestInsertFunction:
             'parsed_request',
             'is_detected',
             'HIVELOGIN',
+            'ua',
+            'dns_name',
+            'country',
+            'continent',
         }
         assert set(record.keys()) == expected_keys
+
+    def test_insert_passes_enrichment_fields_through(self):
+        """Insert should carry ua/dns_name/country/continent into the record dict."""
+        mock_storage = MagicMock()
+
+        bear = BearRequests(
+            ip='1.2.3.4',
+            raw_request='GET /admin HTTP/1.1',
+            timestamp='2024-06-01 12:00:00',
+            parsed_request={'path': '/admin'},
+            is_detected=1,
+            HIVELOGIN='root',
+            ua='Mozilla/5.0 (compatible; bot)',
+            dns_name='scan.example.com',
+            country='Russia',
+            continent='Europe',
+        )
+
+        with patch('manyfaced.db.dbconnect.get_storage', return_value=mock_storage):
+            Insert(bear)
+
+        record = mock_storage.insert.call_args[0][0]
+        assert record['ua'] == 'Mozilla/5.0 (compatible; bot)'
+        assert record['dns_name'] == 'scan.example.com'
+        assert record['country'] == 'Russia'
+        assert record['continent'] == 'Europe'
+
+    def test_insert_enrichment_defaults_to_empty(self):
+        """Enrichment fields should default to '' when not provided."""
+        mock_storage = MagicMock()
+
+        bear = BearRequests(
+            ip='1.2.3.4',
+            raw_request='GET / HTTP/1.1',
+            timestamp='2024-06-01 12:00:00',
+            parsed_request={},
+            is_detected=0,
+            HIVELOGIN='',
+        )
+
+        with patch('manyfaced.db.dbconnect.get_storage', return_value=mock_storage):
+            Insert(bear)
+
+        record = mock_storage.insert.call_args[0][0]
+        assert record['ua'] == ''
+        assert record['dns_name'] == ''
+        assert record['country'] == ''
+        assert record['continent'] == ''

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -535,3 +535,152 @@ class TestSQLiteStorageDirect:
 
         if Path(db_path).exists():
             Path(db_path).unlink(missing_ok=True)
+
+
+class TestEnrichmentPipeline:
+    """Tests for the HTTP enrichment pipeline (ua, dns_name, country, continent)."""
+
+    def test_enrichment_fields_flow_through_save_data(self):
+        """A payload with ua/dns_name/country/continent should reach storage.insert()."""
+        from manyfaced.server.server import ServerHandler
+
+        bear_data = {
+            'ip': '203.0.113.42',
+            'raw_request': 'GET /wp-login.php HTTP/1.1\r\nHost: honeypot\r\n\r\n',
+            'timestamp': '2026-05-14 12:00:00.000000',
+            'parsed_request': {
+                'command': 'GET',
+                'path': '/wp-login.php',
+                'version': 'HTTP/1.1',
+                'headers': {'Host': 'honeypot'},
+            },
+            'is_detected': 1,
+            'HIVELOGIN': '',
+            'ua': 'Mozilla/5.0 (compatible; Nmap Scripting Engine)',
+            'dns_name': 'scanner.example.net',
+            'country': 'United States',
+            'continent': 'North America',
+        }
+
+        args_obj = MagicMock(server=(0, 8090), verbose=False)
+        handler = ServerHandler(args_obj, MagicMock())
+        handler.save_data(bear_data, args_obj)
+
+        import sqlite3
+
+        conn = sqlite3.connect(_resolve_db_path())
+        row = conn.execute(
+            'SELECT bot_user_agent, bot_dns_name, bot_country, bot_continent '
+            'FROM honeypot_bears WHERE bot_ip = ?',
+            ('203.0.113.42',),
+        ).fetchone()
+        conn.close()
+
+        assert row is not None
+        assert row[0] == 'Mozilla/5.0 (compatible; Nmap Scripting Engine)'
+        assert row[1] == 'scanner.example.net'
+        assert row[2] == 'United States'
+        assert row[3] == 'North America'
+
+    def test_enrichment_defaults_to_empty_when_missing(self):
+        """Missing enrichment keys should result in empty strings in the DB."""
+        from manyfaced.server.server import ServerHandler
+
+        bear_data = {
+            'ip': '198.51.100.7',
+            'raw_request': 'GET / HTTP/1.1\r\n\r\n',
+            'timestamp': '2026-05-14 13:00:00.000000',
+            'parsed_request': {'command': 'GET', 'path': '/'},
+            'is_detected': 0,
+            'HIVELOGIN': '',
+        }
+
+        args_obj = MagicMock(server=(0, 8091), verbose=False)
+        handler = ServerHandler(args_obj, MagicMock())
+        handler.save_data(bear_data, args_obj)
+
+        import sqlite3
+
+        conn = sqlite3.connect(_resolve_db_path())
+        row = conn.execute(
+            'SELECT bot_user_agent, bot_dns_name, bot_country, bot_continent '
+            'FROM honeypot_bears WHERE bot_ip = ?',
+            ('198.51.100.7',),
+        ).fetchone()
+        conn.close()
+
+        assert row is not None
+        assert row[0] == ''
+        assert row[1] == ''
+        assert row[2] == ''
+        assert row[3] == ''
+
+
+class TestHostnameFallback:
+    """Tests for hostname extraction with HIVELOGIN fallback."""
+
+    def test_hostname_fallback_to_hivelogin(self):
+        """When record has no 'hostname' key, storage should fall back to HIVELOGIN."""
+        from manyfaced.db.storage import SQLiteStorage
+
+        db_path = 'bots/test_hostname_fallback.sqlite'
+        with SQLiteStorage(db_path) as store:
+            # No 'hostname' key — only HIVELOGIN is present
+            store.insert(
+                {
+                    'ip': '10.99.99.99',
+                    'timestamp': '2026-05-14 14:00:00',
+                    'parsed_request': {'command': 'GET', 'path': '/'},
+                    'is_detected': 1,
+                    'raw_request': 'GET / HTTP/1.1\r\n\r\n',
+                    'HIVELOGIN': 'admin_user',
+                }
+            )
+
+        import sqlite3
+
+        conn = sqlite3.connect(db_path)
+        row = conn.execute(
+            'SELECT hostname FROM honeypot_bears WHERE bot_ip = ?',
+            ('10.99.99.99',),
+        ).fetchone()
+        conn.close()
+
+        assert row is not None
+        assert row[0] == 'admin_user'
+
+        if Path(db_path).exists():
+            Path(db_path).unlink(missing_ok=True)
+
+    def test_hostname_takes_precedence_over_hivelogin(self):
+        """When both hostname and HIVELOGIN are present, hostname wins."""
+        from manyfaced.db.storage import SQLiteStorage
+
+        db_path = 'bots/test_hostname_precedence.sqlite'
+        with SQLiteStorage(db_path) as store:
+            store.insert(
+                {
+                    'ip': '10.88.88.88',
+                    'hostname': 'real-hostname.local',
+                    'timestamp': '2026-05-14 15:00:00',
+                    'parsed_request': {'command': 'GET', 'path': '/'},
+                    'is_detected': 1,
+                    'raw_request': 'GET / HTTP/1.1\r\n\r\n',
+                    'HIVELOGIN': 'admin_user',
+                }
+            )
+
+        import sqlite3
+
+        conn = sqlite3.connect(db_path)
+        row = conn.execute(
+            'SELECT hostname FROM honeypot_bears WHERE bot_ip = ?',
+            ('10.88.88.88',),
+        ).fetchone()
+        conn.close()
+
+        assert row is not None
+        assert row[0] == 'real-hostname.local'
+
+        if Path(db_path).exists():
+            Path(db_path).unlink(missing_ok=True)


### PR DESCRIPTION
## Problem

Recon (2026-05-14) established that enrichment fields (`bot_country`, `bot_continent`, `bot_user_agent`, `bot_dns_name`, `hostname`) are **100% empty** in `honeypot_bears` due to two bugs:

### Bug 1: Server-side pipeline drops enrichment fields
`manyfaced/server/server.py:save_data()` constructs `BearRequests` with only 6 fields (`ip`, `raw_request`, `timestamp`, `parsed_request`, `is_detected`, `HIVELOGIN`). The client already sends `ua`, `dns_name`, `country`, and `continent` in the payload (client.py:266-269), but they are silently discarded before reaching storage.

### Bug 2: Hostname key mismatch
`manyfaced/db/storage.py:167` reads `record.get('hostname')` while the record dict contains the key `'HIVELOGIN'`, so hostname is always empty for the same reason login was correctly populated (login uses a fallback pattern).

## Changes

| File | Change |
|------|--------|
| `manyfaced/db/dbconnect.py` | Add `ua`, `dns_name`, `country`, `continent` to BearRequests dataclass (default `''`) and include them in Insert()'s record dict |
| `manyfaced/server/server.py` | save_data() extracts ua/dns_name/country/continent from the decrypted client payload via `.get()` with defaults |
| `manyfaced/db/storage.py` | Both SQLiteStorage.insert and PostgreSQLStorage.insert now use `record.get('hostname') or record.get('HIVELOGIN') or ''` for hostname extraction |
| `manyfaced/common/geolocate.py` | Geo lookup failure log raised from DEBUG → WARNING (line 73) |
| `manyfaced/common/bearstorage.py` | Geo resolution failure log raised from DEBUG → WARNING (line 94) |

## Tests

- **test_dbconnect**: New tests for enrichment fields on BearRequests, Insert() passing them through, defaults to empty. Updated dataclass_fields assertion.
- **test_integration::TestEnrichmentPipeline**: Full pipeline test — payload with ua/dns_name/country/continent flows through save_data() → SQLite insert with non-empty DB columns.
- **test_integration::TestHostnameFallback**: Verifies HIVELOGIN fallback when hostname key is absent, and hostname precedence when both are present.

## Pre-merge verification

✅ Geo reachability confirmed from prod droplet:
```bash
$ curl -sS --max-time 5 'http://ip-api.com/json/8.8.8.8?fields=country,continentName'
{"country":"United States"}
```

## Post-deploy verification (in PR description)

After deploy: SSH to prod, restart service, wait for new bear records, query the DB:
```sql
SELECT bot_user_agent, bot_dns_name, bot_country, bot_continent, hostname 
FROM honeypot_bears 
WHERE timestamp > '<deploy time>' 
  AND (bot_country != '' OR hostname != '')
LIMIT 5;
```

At least one record with non-empty enrichment columns should appear within 30 minutes.
