### PR TITLE
fix: invert ip-api.com status gate; fix continent field name

### DIFF
--- a/manyfaced/common/geolocate.py
+++ b/manyfaced/common/geolocate.py
@@ -32,7 +32,7 @@ def lookup_ip_geolocation(ip: str, timeout: float = 2.0) -> tuple[str, str]:
         timeout: HTTP request timeout in seconds.
 
     Returns:
-        Tuple of (country_name, continent_code), e.g. ("United States", "NA").
+        Tuple of (country_name, continent_name), e.g. ("United States", "North America").
         Returns ("", "") on any failure.
     """
     global _last_geo_lookup_time
@@ -57,17 +57,21 @@ def lookup_ip_geolocation(ip: str, timeout: float = 2.0) -> tuple[str, str]:
     try:
         import urllib.request
 
-        url = f'http://ip-api.com/json/{ip}?fields=country,continentName'
+        url = f'http://ip-api.com/json/{ip}?fields=country,continent'
         req = urllib.request.Request(url, headers={'User-Agent': 'manyfaced-honeypot'})
         with urllib.request.urlopen(req, timeout=timeout) as response:
             data = json.loads(response.read().decode())
 
-        if data.get('status') == 'success':
-            country = data.get('country', '')
-            continent = data.get('continentName', '')
-            _geo_cache[ip] = {'country': country, 'continent': continent}
-            _last_geo_lookup_time = time.monotonic()
-            return (country, continent)
+        if data.get('status') == 'fail':
+            logger.warning('Geo lookup returned failure for %s: %s', ip, data.get('message', ''))
+            _geo_cache[ip] = {'country': '', 'continent': ''}
+            return ('', '')
+
+        country = data.get('country', '')
+        continent = data.get('continent', '')
+        _geo_cache[ip] = {'country': country, 'continent': continent}
+        _last_geo_lookup_time = time.monotonic()
+        return (country, continent)
 
     except Exception as e:
         logger.warning('Geo lookup failed for %s: %s', ip, e)

--- a/test/test_geolocate.py
+++ b/test/test_geolocate.py
@@ -12,7 +12,8 @@ import pytest
 # ---------------------------------------------------------------------------
 # Ensure project root is importable
 # ---------------------------------------------------------------------------
-import os, sys
+import os
+import sys
 
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if project_root not in sys.path:
@@ -24,6 +25,7 @@ from manyfaced.common.geolocate import lookup_ip_geolocation, clear_geo_cache
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture(autouse=True)
 def _clear_cache():
@@ -37,9 +39,10 @@ def _clear_cache():
 # Test 1: field-restricted success response (no status key) extracts correctly
 # ===================================================================
 
+
 def test_field_restricted_success_no_status_key():
     """ip-api.com omits 'status' from successful responses when fields= is used.
-    
+
     The code must treat a missing status as success and extract country/continent.
     Response shape: {"country": "United States", "continent": "North America"}
     """
@@ -61,6 +64,7 @@ def test_field_restricted_success_no_status_key():
 # ===================================================================
 # Test 2: explicit failure response returns ('', '') and logs WARNING
 # ===================================================================
+
 
 def test_failure_response_logs_warning():
     """When ip-api.com returns status='fail', the function should log a warning,
@@ -88,6 +92,7 @@ def test_failure_response_logs_warning():
 # Test 3: full-status success response still works (backward compat)
 # ===================================================================
 
+
 def test_full_status_success_response():
     """When ip-api.com returns a full response with status='success', the function
     should extract country and continent correctly. This covers any non-field-restricted
@@ -110,6 +115,7 @@ def test_full_status_success_response():
 # ===================================================================
 # Additional edge-case tests
 # ===================================================================
+
 
 def test_empty_response_returns_empty():
     """ip-api.com returns {} for invalid IPs — no status key, no data."""

--- a/test/test_geolocate.py
+++ b/test/test_geolocate.py
@@ -1,0 +1,166 @@
+"""Tests for manyfaced.common.geolocate — IP geolocation lookup via ip-api.com.
+
+Usage:
+    pytest test/test_geolocate.py -v --no-cov
+"""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure project root is importable
+# ---------------------------------------------------------------------------
+import os, sys
+
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+from manyfaced.common.geolocate import lookup_ip_geolocation, clear_geo_cache
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """Clear the geo cache before each test to avoid cross-test pollution."""
+    clear_geo_cache()
+    yield
+    clear_geo_cache()
+
+
+# ===================================================================
+# Test 1: field-restricted success response (no status key) extracts correctly
+# ===================================================================
+
+def test_field_restricted_success_no_status_key():
+    """ip-api.com omits 'status' from successful responses when fields= is used.
+    
+    The code must treat a missing status as success and extract country/continent.
+    Response shape: {"country": "United States", "continent": "North America"}
+    """
+    mock_response = b'{"country": "United States", "continent": "North America"}'
+
+    with patch('urllib.request.urlopen') as mock_urlopen:
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = mock_response
+        mock_resp.__enter__ = lambda self: self
+        mock_resp.__exit__ = lambda self, *a: None
+        mock_urlopen.return_value = mock_resp
+
+        country, continent = lookup_ip_geolocation('8.8.8.8')
+
+    assert country == 'United States'
+    assert continent == 'North America'
+
+
+# ===================================================================
+# Test 2: explicit failure response returns ('', '') and logs WARNING
+# ===================================================================
+
+def test_failure_response_logs_warning():
+    """When ip-api.com returns status='fail', the function should log a warning,
+    cache empty strings, and return ('', '')."""
+    mock_response = b'{"status": "fail", "message": "invalid query"}'
+
+    with patch('urllib.request.urlopen') as mock_urlopen:
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = mock_response
+        mock_resp.__enter__ = lambda self: self
+        mock_resp.__exit__ = lambda self, *a: None
+        mock_urlopen.return_value = mock_resp
+
+        with patch('manyfaced.common.geolocate.logger') as mock_logger:
+            country, continent = lookup_ip_geolocation('1.2.3.4')
+
+    assert country == ''
+    assert continent == ''
+    mock_logger.warning.assert_called_once()
+    call_args = mock_logger.warning.call_args[0]
+    assert 'Geo lookup returned failure' in call_args[0]
+
+
+# ===================================================================
+# Test 3: full-status success response still works (backward compat)
+# ===================================================================
+
+def test_full_status_success_response():
+    """When ip-api.com returns a full response with status='success', the function
+    should extract country and continent correctly. This covers any non-field-restricted
+    call sites or future API changes."""
+    mock_response = b'{"status": "success", "country": "Germany", "continent": "Europe"}'
+
+    with patch('urllib.request.urlopen') as mock_urlopen:
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = mock_response
+        mock_resp.__enter__ = lambda self: self
+        mock_resp.__exit__ = lambda self, *a: None
+        mock_urlopen.return_value = mock_resp
+
+        country, continent = lookup_ip_geolocation('1.1.1.1')
+
+    assert country == 'Germany'
+    assert continent == 'Europe'
+
+
+# ===================================================================
+# Additional edge-case tests
+# ===================================================================
+
+def test_empty_response_returns_empty():
+    """ip-api.com returns {} for invalid IPs — no status key, no data."""
+    mock_response = b'{}'
+
+    with patch('urllib.request.urlopen') as mock_urlopen:
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = mock_response
+        mock_resp.__enter__ = lambda self: self
+        mock_resp.__exit__ = lambda self, *a: None
+        mock_urlopen.return_value = mock_resp
+
+        country, continent = lookup_ip_geolocation('999.999.999.999')
+
+    assert country == ''
+    assert continent == ''
+
+
+def test_cache_reuse():
+    """Repeated lookups for the same IP should return cached results without another HTTP call."""
+    mock_response = b'{"country": "Japan", "continent": "Asia"}'
+
+    with patch('urllib.request.urlopen') as mock_urlopen:
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = mock_response
+        mock_resp.__enter__ = lambda self: self
+        mock_resp.__exit__ = lambda self, *a: None
+        mock_urlopen.return_value = mock_resp
+
+        lookup_ip_geolocation('203.0.113.1')
+        country2, continent2 = lookup_ip_geolocation('203.0.113.1')
+
+    # Second call should not trigger another HTTP request
+    assert mock_urlopen.call_count == 1
+    assert country2 == 'Japan'
+    assert continent2 == 'Asia'
+
+
+def test_private_ip_returns_empty():
+    """Private/loopback IPs should return ('', '') without making an HTTP call."""
+    for ip in ('127.0.0.1', '::1', '10.0.0.1', '192.168.1.1', '172.16.0.1'):
+        with patch('urllib.request.urlopen') as mock_urlopen:
+            country, continent = lookup_ip_geolocation(ip)
+
+        assert mock_urlopen.call_count == 0
+        assert country == ''
+        assert continent == ''
+
+
+# ---------------------------------------------------------------------------
+# Helper: MagicMock is needed but not imported at module level to avoid
+# pulling in urllib mocks before patching. Import here instead.
+# ---------------------------------------------------------------------------
+from unittest.mock import MagicMock


### PR DESCRIPTION
## Summary

Fixes the geolocation lookup bug identified in PR #67's diagnostic (verdict H1): country and continent fields remain empty because `data.get('status') == 'success'` is always false when ip-api.com omits the status key from field-restricted responses.

## Root cause analysis

ip-api.com behaves differently depending on whether `fields=` is used:
- **With `fields=country,continentName`**: Returns `{"country": "United States"}` — no `status` key at all
- **Without fields restriction**: Returns `{"status": "success", ...}` but still no `continentName`

The code was using the field-restricted URL (`fields=country,continentName`) which:
1. Omits the `status` key on success → `data.get('status') == 'success'` is always false
2. Uses wrong field name — free tier returns `continent`, not `continentName`

## Changes

### manyfaced/common/geolocate.py
- **Inverted status gate**: Replace `if data.get('status') == 'success':` with `if data.get('status') == 'fail':` short-circuit. Treat missing/absent status as success; only fail on explicit `'fail'`.
- **Fixed field name**: Changed URL from `fields=country,continentName` to `fields=country,continent` and `.get('continentName', '')` to `.get('continent', '')`.
- **Updated docstring**: Return type now says `(country_name, continent_name)` with example `("United States", "North America")`.

### test/test_geolocate.py (new)
6 tests covering:
1. Field-restricted success without status key → extracts correctly
2. Explicit failure response (`status: fail`) → returns `('', '')` and logs WARNING
3. Full-status success response → backward compatible
4. Empty response `{}` → returns empty strings
5. Cache reuse → no duplicate HTTP calls
6. Private/loopback IPs → skipped without network call

## Pre-merge verification (from prod)

```bash
# With fields=country,continentName — NO continent data:
$ python3 -c "import urllib.request, json; req = urllib.request.Request('http://ip-api.com/json/8.8.8.8?fields=country,continentName', headers={'User-Agent': 'manyfaced-honeypot'}); print(json.loads(urllib.request.urlopen(req, timeout=2).read()))"
{'country': 'United States'}

# With fields=country,continent — continent data present:
$ python3 -c "import urllib.request, json; req = urllib.request.Request('http://ip-api.com/json/8.8.8.8?fields=country,continent', headers={'User-Agent': 'manyfaced-honeypot'}); print(json.loads(urllib.request.urlopen(req, timeout=2).read()))"
{'continent': 'North America', 'country': 'United States'}

# Invalid IP returns empty dict (no status key):
$ python3 -c "import urllib.request, json; req = urllib.request.Request('http://ip-api.com/json/999.999.999.999?fields=country,continent', headers={'User-Agent': 'manyfaced-honeypot'}); print(json.loads(urllib.request.urlopen(req, timeout=2).read()))"
{}
```

**Decision**: Use `fields=country,continent` — the free tier returns full continent names (e.g., "North America") under the key `continent`, not `continentName`.

## Acceptance criteria checklist

- [x] `lookup_ip_geolocation` extracts country/continent from field-restricted success response
- [x] Returns `('', '')` with WARNING log on explicit failure response
- [x] All 6 tests pass locally (356 total, no regressions)
- [x] Pre-merge verification confirms `continent` field availability on prod
- [ ] Post-deploy DB verification (after merge + deploy)
- [x] `git grep "status.*==.*'success'" manyfaced/common/geolocate.py` returns no hits