### PR TITLE
Pin ruff to exact version in dev deps (0.15.13)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
 [project.optional-dependencies]
 postgres = ["psycopg2-binary>=2.9"]
 geoip = ["geoip2>=4.0"]
-dev = ["pytest>=7.0", "ruff>=0.1", "pytest-cov>=4.0", "basedpyright>=1.39"]
+dev = ["pytest>=7.0", "ruff==0.15.13", "pytest-cov>=4.0", "basedpyright>=1.39"]
 
 [project.scripts]
 manyfaced = "manyfaced.mfh:run"


### PR DESCRIPTION
## Summary

Pins `ruff` to exact version `0.15.13` in dev dependencies. Previously `ruff>=0.1` allowed CI to install a newer formatter that produced different output than local, causing `ruff format --check .` to fail on PRs even when code was already formatted locally.

## Why this matters

Ruff's formatting rules can change between minor versions (e.g., 0.15.12 → 0.15.13). Without pinning:
- Local dev uses whatever ruff version is installed
- CI installs the latest from PyPI at run time
- Code formatted locally may fail CI's format check

## Fix

Changed `ruff>=0.1` to `ruff==0.15.13` in `[project.optional-dependencies]`. Both local (0.15.12) and pipx-installed (0.15.13) confirm all 49 files pass formatting — the codebase is compatible with both versions after the format fix applied during PR #74.

Going forward, bumping ruff requires:
1. Update version in pyproject.toml
2. Run `ruff format .` to apply any new formatting rules
3. Commit both changes together
