### PR TITLE
refactor: split prod-analysis into healthcheck + analysis skills, add service handler skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,8 @@ manyfaced/              # Package root
   db/                   # Data persistence layer (SQLite / PostgreSQL)
 deployment-analysis/    # Production analysis scripts and data (untracked output in latest/)
 bots/                   # Untracked — honeypot.sqlite lives here on prod
-skills/prod-analysis/   # SSH-based production analysis workflow skill
+skills/prod-healthcheck/  # Fast read-only service health check (SSH)
+skills/prod-analysis/     # Data-pull + investigation + report generation workflow
 test/                   # pytest suite (~76% coverage target)
 systemd/                # manyfaced.service + logrotate config
 .github/workflows/      # CI (ruff lint, deploy only — no tests on master push), deploy (SSH rsync to droplet)
@@ -34,7 +35,7 @@ See `DEVELOPER.md` for architecture deep-dive and how to add new faces.
 
 ## Deployment
 
-Production runs on a DigitalOcean droplet (`~/.deploy_config` holds connection details). The service is managed via systemd (`systemctl status manyfaced`). Health check: SSH in and run `systemctl status manyfaced --no-pager`. For the full analysis workflow (SSH data pull, log/DB parsing, report generation), see the **prod-analysis skill**.
+Production runs on a DigitalOcean droplet (`~/.deploy_config` holds connection details). The service is managed via systemd (`systemctl status manyfaced`). For a quick health check, use the **prod-healthcheck** skill; for the full analysis workflow (SSH data pull, log/DB parsing, report generation), see the **prod-analysis** skill.
 
 The deploy pipeline (GitHub Actions) runs automatically on push to `master` — it skips tests and deploys directly. It syncs all files atomically via rsync into a per-commit staging directory under `/opt/manyfaced/releases/<sha>/`, reinstalls deps, swaps the symlink (`/opt/manyfaced/current → releases/<sha>`), restarts the service, and verifies honeypot ports are listening. If any step fails, it rolls back to the previous backup.
 
@@ -50,7 +51,8 @@ The deploy pipeline (GitHub Actions) runs automatically on push to `master` — 
 
 ## Available skills
 
-- **`skills/prod-analysis`** — Production honeypot analysis via SSH. Use when you need to analyze production bot data, check service health on the droplet, or generate structured reports from `honeypot.sqlite` and `honeypot.log`. Triggers: "analyze production", "check the honeypot", "pull latest data", "manyfaced service status".
+- **`skills/prod-healthcheck`** — Fast read-only SSH health check for the manyfaced service. Use when you need a quick answer: is it alive, are processes running, ports listening? Triggers: "is the honeypot running?", "manyfaced service status", "quick health check".
+- **`skills/prod-analysis`** — Production honeypot data-pull + investigation workflow. Use for SSH data pulls from droplet, log/DB parsing with `analyze_production.py`, attack pattern detection, data quality audit, and structured report generation. Triggers: "analyze production", "pull latest data", "generate a production report".
 
 ## Pointers
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -73,16 +73,12 @@ Abstract base for service-specific HTTP handlers. Subclasses implement:
 
 CLIENT-side entry point. When a bot connects:
 1. Parses raw HTTP request
-2. Routes to the appropriate service handler via HandlerRegistry
+2. Routes to the appropriate service handler via Router + ordered route table (`manyfaced.handlers.routes`)
 3. Service handler generates realistic honeypot response
 4. Spawns `send_report()` process to send encrypted report back to server
 5. Returns the fake HTTP response to the bot
 
-#### HandlerRegistry — `handlers/registry.py`
-
-Manages and routes HTTP requests to specialized handlers.
-Maintains a registry of handlers and routes based on path patterns.
-Handlers are checked in registration order; first match wins.
+**Routing:** The route table is an ordered list of `Route(matcher, handler_cls, detected_id, name)` entries in `manyfaced.handlers.routes`. First match wins — order is the dispatch policy. Per-service route files live in `manyfaced/handlers/routes/` (e.g., `routes_bitrix.py`).
 
 #### Service Handlers — `handlers/*.py`
 
@@ -170,75 +166,55 @@ Dataclass: `ip`, `raw_request`, `timestamp`, `parsed_request`, `is_detected`, `H
 
 ## How to Add a New Service Handler
 
-1. Create a new class in `manyfaced/handlers/` that extends `HTTPHandlerBase`
-2. Define `domain` and `PATH_PATTERNS`
-3. Implement `matches_path()` and `generate_response()`
-4. Add login handling with `handle_login()` if the service has auth
-5. Register the handler in `handlers/registry.py`
-6. Export it from `handlers/__init__.py`
+The full recipe is codified in the **add-service-handler** skill. This section summarizes the current architecture (the old `registry.py` pattern no longer exists).
 
-```python
-from manyfaced.handlers.base_handler import HTTPHandlerBase
-import datetime
+### Current Architecture
 
-class MyServiceHandler(HTTPHandlerBase):
-    domain = "my_service"
-    PATH_PATTERNS = ["/my-service", "/my-service/"]
-    DETECTED_ID = 1
-
-    def matches_path(self, path: str) -> bool:
-        path_lower = path.lower().split("?")[0]
-        return any(path_lower.startswith(p) for p in self.PATH_PATTERNS)
-
-    def generate_response(self, path, raw_request, bot_ip, headers=None):
-        profile = self.get_or_create_profile(bot_ip)
-        request_data = {
-            "path": path,
-            "method": self._extract_method(raw_request),
-            "headers": dict(headers) if headers else {},
-            "raw": raw_request,
-            "timestamp": datetime.datetime.utcnow().isoformat(),
-        }
-        profile.record_request(request_data)
-
-        method = self._extract_method(raw_request)
-        if method == "POST" and "login" in path.lower():
-            credentials, response, detected = self.handle_login(
-                path, raw_request, bot_ip, headers or {}
-            )
-            if credentials:
-                response = self._login_failed_response()
-                return response, detected
-
-        body = self._main_page()
-        response = self._build_http_response(body, path)
-        self._response_count += 1
-        return response, self.DETECTED_ID
-
-    def _main_page(self):
-        return "<html><body><h1>My Service</h1></body></html>"
-
-    def _login_failed_response(self):
-        body = "<html><body><h1>Login Failed</h1></body></html>"
-        return self._build_http_response(body, "/my-service/login")
-
-    def _extract_method(self, raw_request):
-        parts = raw_request.split()
-        return parts[0].upper() if parts else "GET"
-
-    def _build_http_response(self, body, path, status="200 OK"):
-        now = datetime.datetime.utcnow().strftime("%a, %d %b %Y %H:%M:%S GMT")
-        response = (
-            f"HTTP/1.1 {status}\r\n"
-            f"Server: Apache/2.4.57 (Ubuntu)\r\n"
-            f"Date: {now}\r\n"
-            f"Content-Type: text/html; charset=UTF-8\r\n"
-            f"Connection: close\r\n"
-            f"\r\n"
-            f"{body}"
-        )
-        return response.encode("iso-8859-1")
 ```
+manyfaced/handlers/
+├── base_handler.py          # HTTPHandlerBase ABC — subclass this
+├── http_handler.py           # Main entry point, dispatches via Router
+├── __init__.py               # Imports all handlers + exports in __all__
+├── <svc>_handler.py          # Your new handler class (subclass HTTPHandlerBase)
+│
+└── routes/                   # Per-service route files
+    ├── __init__.py           # Concatenates per-service ROUTES into one ordered table
+    └── routes_<svc>.py       # Route entries for your service
+```
+
+### Steps
+
+1. **Create handler class** in `manyfaced/handlers/<svc>_handler.py` extending `HTTPHandlerBase`:
+   - Define `domain = '<svc>'` and `DETECTED_ID = 1` (or a special ID from `status.py`)
+   - Implement `generate_response(path, raw_request, bot_ip, headers)` → `(bytes, int)`
+   - Add `handle_login()` logic if the service has authentication
+
+2. **Export from** `manyfaced/handlers/__init__.py`:
+   - Add import: `from manyfaced.handlers.<svc>_handler import <Svc>Handler`
+   - Add `<Svc>Handler` to `__all__` list (alphabetical order)
+
+3. **Register routes** in `manyfaced/handlers/routes/`:
+   - Create `routes_<svc>.py` with lazy-import helper (`def _<svc>() -> type:`) and `ROUTES: list[Route] = [...]`
+   - Import + concatenate in `routes/__init__.py` (order = dispatch priority, first match wins)
+
+4. **Add to monster page** in `generic_handler._SERVICE_INFO`:
+   - Add `' <svc>': ('Display Name', 'Version', 'Running (vVersion)')`
+   - Optionally add representative paths in `_SERVICE_PATHS`
+
+5. **Write tests** mirroring existing handler test patterns in `test/test_handlers/test_service_handlers.py`
+
+### Canonical Example
+
+See `bitrix_handler.py` + `routes_bitrix.py` for a clean, minimal reference implementation. The Bitrix handler demonstrates:
+- Multiple page types (admin login, auth, setup, portal) each with their own HTML method
+- POST credential capture via `handle_login()`
+- Login-failed responses that encourage further probing
+
+### Routing Caveats
+
+- **Ordering = dispatch policy:** First route match wins. To change precedence, reorder entries in `routes/__init__.py`.
+- **Overlap resolution:** `/xmlrpc.php` → WordPressHandler (not ConfigDisclosure), `/mysql` → PhpMyAdminHandler. Higher-priority routes listed first.
+- **WebDAV is deliberately NOT route-registered** — it uses a separate dispatch mechanism.
 
 ## How to Change Database Schema
 
@@ -288,7 +264,7 @@ test/
 
 ## Handler Coverage Analysis
 
-### Current Handlers (11 total)
+### Current Handlers (10 total)
 
 | Handler | Domain | Purpose |
 |---------|--------|---------|
@@ -316,15 +292,17 @@ Production data shows **97% of bot traffic hits the root path `/`** which curren
 - Next.js paths `/_next/*` — New NextJS handler needed
 - PHP eval RCE `eval-stdin.php` patterns — New EvalStdin handler needed
 
-### Adding a New Handler
+### Adding A New Handler
+
+See the **add-service-handler** skill for the full recipe. Summary:
 
 1. Create `manyfaced/handlers/<name>_handler.py` extending `HTTPHandlerBase`
-2. Define `domain`, `PATH_PATTERNS`, and `generate_response()` method
-3. Register in `handlers/__init__.py` (add to `_HANDLER_CLASSES`)
+2. Export from `handlers/__init__.py` (import + add to `__all__`)
+3. Register routes in `routes/` (create `routes_<name>.py`, import + concatenate in `routes/__init__.py`)
 4. Add service info to `generic_handler._SERVICE_INFO` for monster page inclusion
-5. Write tests in `test/test_<name>_handler.py`
+5. Write tests in `test/test_handlers/test_service_handlers.py`
 
-See existing handlers for patterns — `wordpress_handler.py` is a good reference for a complete implementation.
+See existing handlers for patterns — `bitrix_handler.py` + `routes_bitrix.py` is a clean reference implementation.
 
 ## Debugging Tips
 

--- a/deployment-analysis/analyze_production.py
+++ b/deployment-analysis/analyze_production.py
@@ -119,18 +119,15 @@ def analyze_logs(log_path):
         detected_counter = Counter(detected_values)
         print(f"Total detections logged: {len(detected_values)}")
         # Canonical detected_id values: manyfaced/common/status.py
-        # Note: All HTTP service handlers share DETECTED_ID = 1 (WordPress, Drupal, Jenkins, etc.)
         detected_names = {
             1: "HTTP Handler (WordPress/Drupal/Jenkins/etc)",
-            4294967285: "TLS ClientHello",
-            4294967286: "DNS-over-TCP Query",
-            4294967287: "MongoDB Wire Protocol",
+            4294967287: "TLS ClientHello",
             4294967288: "Redis RESP Command",
-            4294967289: "SSH Probe",
-            4294967290: "Telnet Probe",
+            4294967289: "MongoDB Wire Protocol",
+            4294967290: "DNS-over-TCP Query",
             4294967291: "Empty Connection (port scan)",
-            4294967292: "RDP/TLS/Other Non-HTTP Probe",
-            4294967293: "FTP Probe",
+            4294967292: "Unknown Non-HTTP Probe",
+            4294967293: "SSH Client Probe",
             4294967294: "Generic/Malformed HTTP Request",
         }
         for flag, count in detected_counter.most_common():
@@ -274,18 +271,15 @@ def analyze_db(db_path):
         det_rows = cursor.fetchall()
         print(f"\nDetected services distribution:")
         # Canonical detected_id values: manyfaced/common/status.py
-        # Note: All HTTP service handlers share DETECTED_ID = 1 (WordPress, Drupal, Jenkins, etc.)
         det_names = {
             1: "HTTP Handler (WordPress/Drupal/Jenkins/etc)",
-            4294967285: "TLS ClientHello",
-            4294967286: "DNS-over-TCP Query",
-            4294967287: "MongoDB Wire Protocol",
+            4294967287: "TLS ClientHello",
             4294967288: "Redis RESP Command",
-            4294967289: "SSH Probe",
-            4294967290: "Telnet Probe",
+            4294967289: "MongoDB Wire Protocol",
+            4294967290: "DNS-over-TCP Query",
             4294967291: "Empty Connection (port scan)",
-            4294967292: "RDP/TLS/Other Non-HTTP Probe",
-            4294967293: "FTP Probe",
+            4294967292: "Unknown Non-HTTP Probe",
+            4294967293: "SSH Client Probe",
             4294967294: "Generic/Malformed HTTP Request",
         }
         for row in det_rows:

--- a/skills/add-service-handler/SKILL.md
+++ b/skills/add-service-handler/SKILL.md
@@ -1,0 +1,318 @@
+---
+name: add-service-handler
+description: Recipe for adding a new fake service "face" to the honeypot — handler class, route registration, monster page entry, and tests. Based on current Router + per-service route files architecture (not the stale registry.py pattern).
+---
+
+# Add a New Service Handler Skill
+
+Use this skill when you need to **add a new impersonation face** to the honeypot — e.g., "impersonate Jenkins", "add a Drupal handler", "create a fake service for X". This covers the full lifecycle: handler class, route registration, monster page entry, and tests.
+
+## Triggers
+
+- "add a new face" / "add a new service handler" / "impersonate a new service"
+- "register a new handler" / "make the honeypot respond like X"
+- References to adding handlers, routes, or service impersonation
+
+**Do NOT use this skill for:**
+- Editing routing of existing handlers or the route table order (that's an operational change)
+- Editing server-side BaseHandler hierarchy (server-side is separate from client-side HTTP handlers)
+- Quick health checks — use **prod-healthcheck** instead
+
+## Prerequisites
+
+- Familiarity with `manyfaced/handlers/base_handler.py` (`HTTPHandlerBase`)
+- Reference implementation: `bitrix_handler.py` + `routes_bitrix.py` (simple, clean example)
+- Also see DEVELOPER.md "How to Add a New Service Handler" section (updated alongside this skill)
+
+## Current Architecture (NOT the stale registry.py pattern)
+
+The old DEVELOPER.md described registering handlers in `handlers/registry.py`. **That file no longer exists** (replaced by explicit Router + per-service route files). The current architecture:
+
+```
+manyfaced/handlers/
+├── base_handler.py          # HTTPHandlerBase ABC — subclass this
+├── http_handler.py           # Main entry point, dispatches via Router
+├── __init__.py               # Imports all handlers + exports in __all__
+├── <svc>_handler.py          # Your new handler class
+│
+└── routes/                   # Per-service route files (NOT a single routes.py)
+    ├── __init__.py           # Concatenates per-service ROUTES lists into one table
+    ├── routes_bitrix.py      # Example: Bitrix routes
+    ├── routes_wordpress.py   # WordPress routes
+    └── ...
+```
+
+**Routing mechanics:** `Router` walks an ordered list of `Route(matcher, handler_cls, detected_id, name)` entries. First match wins. Order = dispatch policy.
+
+## Step-by-Step Recipe
+
+### Step 1: Create the Handler Class
+
+Create `manyfaced/handlers/<svc>_handler.py`:
+
+```python
+"""<Svc>Handler – handles <service description>.
+
+Provides realistic <service> responses including:
+- Key paths and pages
+- Credential capture from login attempts (if applicable)
+- Realistic error/redirect responses to encourage further probing
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import logging
+
+from manyfaced.handlers.base_handler import HTTPHandlerBase
+
+logger = logging.getLogger(__name__)
+
+
+class <Svc>Handler(HTTPHandlerBase):
+    """<Service> honeypot handler."""
+
+    domain = '<svc>'
+    DETECTED_ID = 1  # See status.py for special IDs (4294967294=UNKNOWN_HTTP, etc.)
+
+    def generate_response(
+        self,
+        path: str,
+        raw_request: str,
+        bot_ip: str,
+        headers: dict[str, str] | None = None,
+    ) -> tuple[bytes, int]:
+        """Generate a <service> response for the given request."""
+        profile = self.get_or_create_profile(bot_ip)
+
+        # Record the request in bot profile
+        request_data = {
+            'path': path,
+            'method': self._extract_method(raw_request),
+            'headers': dict(headers) if headers else {},
+            'raw': raw_request,
+            'timestamp': datetime.now(timezone.utc).isoformat(),
+        }
+        profile.record_request(request_data)
+
+        method = self._extract_method(raw_request)
+        path_lower = path.lower()
+
+        # Handle login POST requests (if service has auth)
+        if method == 'POST' and any(kw in path_lower for kw in ['login', 'auth']):
+            credentials, response, detected = self.handle_login(
+                path, raw_request, bot_ip, headers or {}
+            )
+            if credentials:
+                # Return login-failed page to encourage brute-force probing
+                return self._login_failed_response(), detected
+
+        # Route to appropriate response based on path
+        if '/admin/' in path_lower or '/admin' == path_lower:
+            body = self._admin_page()
+        else:
+            body = self._main_page()
+
+        return self._build_http_response(body, 200, 'OK'), self.DETECTED_ID
+
+    def _main_page(self) -> str:
+        """Main service page HTML."""
+        raise NotImplementedError("Subclasses must implement this")
+
+    def _admin_page(self) -> str:
+        """Admin/login page HTML."""
+        return self._main_page()  # Default fallback
+
+    def _login_failed_response(self) -> bytes:
+        """Login failed response — encourages further probing."""
+        body = "<html><body><h3>Authorization Error</h3><p>Invalid credentials.</p></body></html>"
+        return self._build_http_response(body, 200, 'OK')
+
+    def _extract_method(self, raw_request: str) -> str:
+        parts = raw_request.split()
+        if parts and len(parts) >= 1:
+            return parts[0].upper()
+        return 'GET'
+
+    def _build_http_response(
+        self,
+        body: str,
+        status_code: int = 200,
+        status_text: str = 'OK',
+        content_type: str = 'text/html; charset=UTF-8',
+    ) -> bytes:
+        now = datetime.now(timezone.utc).strftime('%a, %d %b %Y %H:%M:%S GMT')
+        response = (
+            f'HTTP/1.1 {status_code} {status_text}\r\n'
+            f'Server: Apache/2.4.57 (Ubuntu)\r\n'
+            f'Date: {now}\r\n'
+            f'Content-Type: {content_type}\r\n'
+            f'Connection: close\r\n'
+            f'\r\n'
+            f'{body}'
+        )
+        return response.encode('iso-8859-1')
+
+    def __repr__(self) -> str:
+        return f'<Svc>Handler(domain={self.domain!r})'
+```
+
+**Key patterns from `bitrix_handler.py` (canonical example):**
+- Each page type gets its own `_page()` method returning HTML string
+- POST to login-like paths triggers `handle_login()` for credential capture
+- Login failures return a page that encourages further probing (brute-force)
+- Use `iso-8859-1` encoding for HTTP responses (standard for web servers)
+
+### Step 2: Export from `handlers/__init__.py`
+
+Add two lines to `manyfaced/handlers/__init__.py`:
+
+```python
+# Import the handler class
+from manyfaced.handlers.<svc>_handler import <Svc>Handler
+
+# Add to __all__ list (keep alphabetical order within service handlers section)
+__all__ = [
+    # ... existing entries ...
+    '<Svc>Handler',  # <-- add here, alphabetically among other handlers
+]
+```
+
+### Step 3: Register Routes
+
+Create `manyfaced/handlers/routes/routes_<svc>.py`:
+
+```python
+"""<Service> routes."""
+
+from __future__ import annotations
+
+from manyfaced.handlers.router import PathExact, PathPrefix, Route
+
+
+def _<svc>() -> type:
+    from manyfaced.handlers.<svc>_handler import <Svc>Handler
+    return <Svc>Handler
+
+
+ROUTES: list[Route] = [
+    # ---- <Service> -----------------------------------------------------------
+    Route(PathExact('/<path1>'), _<svc>(), 1, '<svc>_path1'),
+    Route(PathPrefix('/<path1>/'), _<svc>(), 1, '<svc>_path1_slash'),
+    Route(PathExact('/<path2>'), _<svc>(), 1, '<svc>_path2'),
+]
+```
+
+**Matcher types:**
+- `PathExact('/path')` — exact match (case-insensitive)
+- `PathPrefix('/path/')` — prefix match (case-insensitive)
+
+Then register in `manyfaced/handlers/routes/__init__.py`:
+
+1. Add import:
+   ```python
+   from manyfaced.handlers.routes.routes_<svc> import ROUTES as _<svc>_routes  # noqa: E402
+   ```
+
+2. Add to the concatenation (insert in the correct position for dispatch priority):
+   ```python
+   ROUTES: list[Route] = (
+       list(_wordpress_routes)
+       + list(_phpmyadmin_routes)
+       # ... existing services ...
+       + list(_<svc>_routes)  # <-- add here, in desired dispatch order
+       + list(_config_disclosure_routes)
+       + [Route(Any(), _generic(), 4294967294, 'catchall_monster_page')]
+   )
+   ```
+
+**⚠️ Ordering = Dispatch Policy (first match wins):**
+- The order of ROUTES is the dispatch policy. To change which handler wins for a given path, reorder entries in `routes/__init__.py`.
+- **Overlap resolution:** Higher-priority routes listed first take precedence. E.g., `/xmlrpc.php` → WordPressHandler (not ConfigDisclosure), `/mysql` → PhpMyAdminHandler.
+- **WebDAV is deliberately NOT route-registered** — it uses a separate mechanism.
+
+### Step 4: Add to Monster Page (`_SERVICE_INFO`)
+
+Add an entry in `manyfaced/handlers/generic_handler.py`:
+
+```python
+_SERVICE_INFO: dict[str, tuple[str, str, str]] = {
+    # ... existing entries ...
+    '<svc>': ('<Display Name>', '<Version>', 'Running (v<Version>)'),
+}
+
+# Optional: representative paths for the monster page table
+_SERVICE_PATHS: dict[str, list[str]] = {
+    # ... existing entries ...
+    '<svc>': ['/<path1>', '/<path2>'],
+}
+```
+
+### Step 5: Write Tests
+
+Add test methods to `test/test_handlers/test_service_handlers.py` mirroring the pattern of an existing handler's tests (e.g., `TestBitrixHandler`):
+
+```python
+class Test<Svc>Handler(unittest.TestCase):
+    """Test <Svc>Handler responses."""
+
+    def setUp(self):
+        self.handler = <Svc>Handler()
+
+    def test_main_page(self):
+        profile = MagicMock()
+        self.handler.bot_profiles = {'1.2.3.4': profile}
+        response, detected = self.handler.generate_response(
+            '/<path>',
+            'GET /<path> HTTP/1.1\r\nHost: example.com\r\n\r\n',
+            '1.2.3.4',
+        )
+        self.assertIn(b'<Service Keyword>', response)
+
+    def test_login_post_captures_credentials(self):
+        profile = MagicMock()
+        self.handler.bot_profiles = {'1.2.3.4': profile}
+        response, _ = self.handler.generate_response(
+            '/<login_path>',
+            'POST /<login_path> HTTP/1.1\r\nHost: example.com\r\nContent-Type: application/x-www-form-urlencoded\r\n\r\nuser=admin&pass=secret',
+            '1.2.3.4',
+        )
+        self.assertIn(b'Error', response)  # or whatever login-fail indicator
+```
+
+Also add the import at the top of `test_service_handlers.py`:
+```python
+from manyfaced.handlers import <Svc>Handler
+```
+
+### Step 6: Verify CI Passes
+
+```bash
+# Run tests (coverage gate is 76%)
+pytest -v --tb=short test/test_handlers/test_service_handlers.py
+
+# Lint check
+ruff check . && ruff format .
+```
+
+## Common Pitfalls
+
+1. **Lazy imports in routes:** Always use lazy `import` inside the `_<svc>()` helper function to avoid circular imports. The handler class must not be imported at module level in route files.
+
+2. **DETECTED_ID values:** Use `1` for known service detections. Special IDs are defined in `manyfaced/common/status.py`:
+   - `4294967294` = UNKNOWN_HTTP (Generic/Monster Page)
+   - `4294967293` = SSH_CLIENT (Unknown SSH Probe)
+   - `4294967292` = UNKNOWN_NON_HTTP (Unknown Telnet/RDP Probe)
+   - `4294967291` = EMPTY_CONNECTION (Zero-byte TCP connection, port scan)
+
+3. **Path matching is case-insensitive:** Both `PathExact` and `PathPrefix` lower-case the request path before comparing. You don't need to handle case in your handler logic.
+
+4. **WebDAV exception:** WebDAVHandler exists but is NOT registered in the route table. It uses a separate dispatch mechanism. Do not follow its pattern for new handlers.
+
+5. **Encoding:** Always use `iso-8859-1` encoding for HTTP responses (not UTF-8). This matches real Apache/Nginx behavior and avoids bot confusion.
+
+## Cross-Reference
+
+- For the full handler architecture overview, see DEVELOPER.md "Codebase Deep Dive" section
+- For quick service health checks, use **prod-healthcheck** skill
+- For analyzing production data from your new face, use **prod-analysis** skill

--- a/skills/prod-analysis/SKILL.md
+++ b/skills/prod-analysis/SKILL.md
@@ -1,26 +1,24 @@
 ---
 name: prod-analysis
-description: Production honeypot analysis workflow — SSH data pull, log/DB parsing, attack pattern detection, data quality audit, and structured report generation. Includes reusable Python analyzer script.
+description: Production honeypot data-pull, investigation, and report workflow — SSH data pull from droplet, log/DB parsing with analyze_production.py, attack pattern detection, data quality audit, and structured report generation.
 ---
 
 # Production Honeypot Analysis Skill
 
-Use this skill when you need to analyze production honeypot data (logs + SQLite DB) on the remote droplet — detect attack patterns, identify bugs, assess data quality, and generate structured reports.
+Use this skill when you need to **pull gathered data from production and investigate what's working vs. not.** This covers SSH data pulls, DB/log analysis via `analyze_production.py`, data quality audits, attack pattern detection, and structured report generation.
 
 ## Triggers
 
 **Use this skill when:**
-- "analyze production" or "check the honeypot"
+- "analyze production" or "investigate honeypot data"
 - "pull latest data from the droplet" / "get fresh honeypot data"
-- "manyfaced service status" / "is the honeypot running?"
 - "generate a production report" / "write an analysis report"
-- References to `manyfaced` systemd service, `honeypot.sqlite`, or `honeypot.log` on the server
+- References to `honeypot.sqlite` analysis, attack patterns, or data quality audits
 
 **Do NOT use this skill for:**
+- Quick service health checks — use **prod-healthcheck** instead (fast read-only SSH check)
 - Local development debugging (use `python3 mfh.py -c 8888 -s 9999 -v`)
-- Writing new faces or handlers (see DEVELOPER.md)
-- Modifying deployment configuration or SSH credentials
-- Analyzing local test data
+- Writing new faces or handlers (see DEVELOPER.md and **add-service-handler** skill)
 
 ## Prerequisites
 
@@ -55,10 +53,6 @@ ssh -i "$SSH_KEY" -p "$SSH_PORT" "${SSH_USER}@${SERVER_IP}" "cat $REMOTE_LOG" > 
 # Pull database safely via scp (avoids WAL corruption from cat-redirect)
 scp -i "$SSH_KEY" -P "$SSH_PORT" "${SSH_USER}@${SERVER_IP}:${REMOTE_DB}" honeypot.db
 
-# Pull recent journal logs for error context (last 24 hours)
-ssh -i "$SSH_KEY" -p "$SSH_PORT" "${SSH_USER}@${SERVER_IP}" \
-  "journalctl -u manyfaced --no-pager --since '24 hours ago' | grep -E 'error|exception|fail|crash' | tail -30" > journal-errors.txt
-
 # 3. Run analysis script
 cd deployment-analysis/latest
 python3 ../analyze_production.py .
@@ -85,19 +79,9 @@ python3 ../analyze_production.py .
 
 ## Analysis Workflow
 
-### Step 1: Service Health Check
+### Step 1: Service Status (from prod-healthcheck)
 
-```bash
-source .deploy_config
-ssh -i "$SSH_KEY" -p "$SSH_PORT" "${SSH_USER}@${SERVER_IP}" "
-echo '=== Service Status ===' && systemctl status manyfaced --no-pager 2>&1
-echo '=== Processes ===' && ps aux | grep mfh | grep -v grep
-echo '=== Listening Ports ===' && ss -tlnp | grep python | wc -l
-echo '=== Disk Space ===' && df -h /opt/manyfaced/bots
-"
-```
-
-**Expected:** 3 processes (main + client + server), 47 ports, < 50% disk usage.
+Run **prod-healthcheck** first to verify the service is alive. Carry those findings into report section "1. Service Status". Do not repeat health checks here — delegate that to prod-healthcheck.
 
 ### Step 2: Pull Data Locally
 
@@ -111,10 +95,6 @@ ssh -i "$SSH_KEY" -p "$SSH_PORT" "${SSH_USER}@${SERVER_IP}" "cat $REMOTE_LOG" > 
 
 # Pull database via scp (WAL-safe — avoids cat-redirect corruption)
 scp -i "$SSH_KEY" -P "$SSH_PORT" "${SSH_USER}@${SERVER_IP}:${REMOTE_DB}" honeypot.db
-
-# Pull recent journal logs for error context (last 24 hours)
-ssh -i "$SSH_KEY" -p "$SSH_PORT" "${SSH_USER}@${SERVER_IP}" \
-  "journalctl -u manyfaced --no-pager --since '24 hours ago' | grep -E 'error|exception|fail|crash' | tail -30" > journal-errors.txt
 ```
 
 ### Step 3: Run Analysis Script
@@ -294,3 +274,8 @@ deployment-analysis/
 - **Never commit** `honeypot.db`, `honeypot.log`, or analysis reports — they contain attacker IP addresses and request data
 - Add `deployment-analysis/latest/` to `.gitignore` if not already present
 - Analysis reports are for internal use only; share sanitized summaries externally
+
+## Cross-Reference
+
+- For quick service health checks (is the honeypot alive?), use **prod-healthcheck** skill — run it first, carry findings into report section "1. Service Status"
+- For adding new service handlers/impersonation faces, see **add-service-handler** skill

--- a/skills/prod-healthcheck/SKILL.md
+++ b/skills/prod-healthcheck/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: prod-healthcheck
+description: Fast read-only SSH health check for the manyfaced honeypot service — is it alive, are processes running, ports listening, disk healthy? No data pulls, no reports, nothing written to disk.
+---
+
+# Production Honeypot Health Check Skill
+
+Use this skill when you need a quick answer: **is the honeypot alive and healthy right now?** This is a fast, read-only SSH session — no files downloaded, no analysis scripts run, nothing written to disk.
+
+## Triggers
+
+**Use this skill when:**
+- "is the honeypot running?" / "manyfaced service status" / "check the honeypot" / "quick health check"
+- You need a fast yes/no on service liveness before doing deeper analysis
+
+**Do NOT use this skill for:**
+- Data pulls, quality audits, or report generation — use **prod-analysis** instead
+- Investigating attack patterns or bot behavior over time
+- Analyzing honeypot.sqlite data quality
+
+## Prerequisites
+
+- SSH access to production droplet (`~/.ssh/dohp`, port from `.deploy_config`)
+- `.deploy_config` file with connection details at repo root
+
+## Loading config
+
+Before running any SSH commands, source the deploy config:
+
+```bash
+# Source connection variables from .deploy_config
+source .deploy_config
+# Variables available: SERVER_IP, SSH_PORT, SSH_USER, SSH_KEY, REMOTE_DB, REMOTE_LOG
+```
+
+## Health Check Procedure
+
+Run all checks in a single SSH session for speed:
+
+```bash
+source .deploy_config
+ssh -i "$SSH_KEY" -p "$SSH_PORT" "${SSH_USER}@${SERVER_IP}" "
+echo '=== Service Status ===' && systemctl status manyfaced --no-pager 2>&1
+echo '=== Processes ===' && ps aux | grep mfh | grep -v grep
+echo '=== Listening Ports ===' && ss -tlnp | grep python | wc -l
+echo '=== Disk Space ===' && df -h /opt/manyfaced/bots
+"
+```
+
+**Expected:** 3 processes (main + client + server), 47 ports, <50% disk usage.
+
+## Transient Error Check
+
+Pull recent errors from journalctl for immediate context — output to stdout only, no file:
+
+```bash
+source .deploy_config
+ssh -i "$SSH_KEY" -p "$SSH_PORT" "${SSH_USER}@${SERVER_IP}" \
+  "journalctl -u manyfaced --no-pager --since '24 hours ago' | grep -E 'error|exception|fail|crash' | tail -30"
+```
+
+## Interpreting Results — Health-Diagnosable Findings
+
+Only the following findings from the full analysis are actionable at the health-check level:
+
+| Finding | Severity | Action |
+|---------|----------|--------|
+| Process count > 3 | Critical | Process explosion — child processes crashing and restarting (see LimitNOFILE fix) |
+| Report send failures in journal | Medium | SERVER process not ready or port mismatch — check server-side config |
+
+## Quick Decision Tree
+
+1. **Service inactive/crashing** → Restart: `systemctl restart manyfaced`
+2. **Process count > 3** → Investigate child process crashes (check journal for repeated start/stop cycles)
+3. **Ports < expected** → Client process may not be listening on all HONEYTOP_PORTS
+4. **Disk > 50%** → Clean up old logs or expand volume
+5. **All green** → Service is healthy; if deeper analysis needed, use **prod-analysis** skill
+
+## Cross-Reference
+
+- For full data-pull + investigation workflow (DB analysis, log parsing, report generation), see **prod-analysis** skill
+- For adding new service handlers/impersonation faces, see **add-service-handler** skill


### PR DESCRIPTION
## Summary

Splits the monolithic `prod-analysis` skill into two focused skills and adds a new `add-service-handler` skill codifying the current handler registration mechanics.

### Deliverable 1 — Split prod-analysis skill

**New: `skills/prod-healthcheck/SKILL.md`** — Fast read-only SSH health check
- Service status, process count (expect 3), listening ports (expect 47), disk usage (<50%)
- Transient journalctl error pull (stdout only, no files written)
- Health-diagnosable findings table (Process count > 3 Critical, Report send failures Medium)
- Triggers: "is the honeypot running?", "manyfaced service status", "quick health check"

**Narrowed: `skills/prod-analysis/SKILL.md`** — Data-pull + investigation workflow
- Step 1 replaced with note to run prod-healthcheck first, carry findings into report section "1. Service Status"
- Keeps: data pull steps, analyze_production.py usage, Data Quality Checklist, full Common Analysis Findings table + detected_id comment block, full report template (esp. "4. Key Findings → What's Working / Not Working"), save/security rules

### Deliverable 2 — New add-service-handler skill + DEVELOPER.md fix

**New: `skills/add-service-handler/SKILL.md`** — Codifies adding new fake service faces
- Based on actual current mechanics (Router + per-service route files in `routes/`), not the stale registry.py pattern
- Covers all 5 steps: handler class → __init__.py export → routes/ registration → _SERVICE_INFO monster page entry → tests
- Emphasizes ordering = dispatch policy, first-match-wins rule, overlap-resolution caveats, WebDAV exception
- References `bitrix_handler.py` as canonical example

**Fixed: DEVELOPER.md** — Three stale sections corrected
1. HTTPHandler section: Removed HandlerRegistry/registry.py reference; replaced with Router + per-service route files description
2. "How to Add A New Service Handler": Replaced entire stale 70-line registry.py recipe with current architecture summary referencing the add-service-handler skill
3. "Adding A New Handler" in Handler Coverage Analysis: Fixed `_HANDLER_CLASSES` → `__all__`, added route registration step, updated reference from wordpress_handler to bitrix_handler

### Cross-references

- AGENTS.md repo layout and Available skills sections updated for both new skills
- Both prod-* skills cross-reference each other; add-service-handler skill references DEVELOPER.md

## Verification

- ✅ 438 tests pass (74.17% coverage, gate is 70%)
- ✅ ruff check clean