### PR TITLE
fix: missing argument in report send failure log format string

### DIFF
--- a/manyfaced/client/report_sender.py
+++ b/manyfaced/client/report_sender.py
@@ -95,6 +95,7 @@ def send_report(data, client, password, server_host, server_port, sensor_id=None
                     'Report send failed for %s (attempt %d/%d), retrying in %ds',
                     client,
                     attempt,
+                    REPORT_SEND_MAX_RETRIES,
                     delay,
                 )
                 time.sleep(delay)


### PR DESCRIPTION
## What's broken

The log message at `manyfaced/client/report_sender.py:95` uses a `\%-`style format string with 4 placeholders (`\%s, \%d/\%d, \%ds`) but only passes 3 arguments. This causes a `TypeError: not enough arguments for format string` that masks the actual underlying error (a `TimeoutError`).

## Fix

Added the missing `REPORT_SEND_MAX_RETRIES` argument so the log message formats correctly and the real timeout reason is visible in production logs.