### PR TITLE
fix: send SSH reports after credential capture

### DIFF
--- a/manyfaced/client/client.py
+++ b/manyfaced/client/client.py
@@ -109,6 +109,9 @@ def create_server(args, update_event: Event, port: int):
                             bot_ip,
                             ssh_creds,
                         )
+                    # Send report AFTER credential capture so login field has real creds
+                    if bear_storage is not None:
+                        handler._enrich_and_send(bear_storage, bot_ip)
                 connection_socket.close()
             except socket_error:
                 if args.verbose:

--- a/manyfaced/client/server_factory.py
+++ b/manyfaced/client/server_factory.py
@@ -70,16 +70,32 @@ def _handle_bot_connection(
 
     try:
         logger.debug('Sending response of length %d', len(output_data))
-        connection_socket.sendall(
-            output_data if isinstance(output_data, bytes) else output_data.encode('iso-8859-1')
-        )
-        # For SSH connections, keep the connection open to capture credentials
-        if isinstance(output_data, bytes) and output_data.startswith(b'SSH-'):
-            from manyfaced.client.ssh_creds import _capture_ssh_credentials
+        # Handle both SSH/non-HTTP (returns tuple) and HTTP (returns bytes) paths
+        if isinstance(output_data, tuple):
+            # SSH or non-HTTP probe: (response_bytes, BearStorage)
+            response_bytes, bear_storage = output_data
+            connection_socket.sendall(response_bytes)
 
-            ssh_creds = _capture_ssh_credentials(connection_socket, bot_ip)
-            if ssh_creds:
-                logger.info('Captured SSH credentials from %s: %s', bot_ip, ssh_creds)
+            # For SSH connections, keep the connection open to capture credentials
+            if response_bytes.startswith(b'SSH-'):
+                from manyfaced.client.ssh_creds import _capture_ssh_credentials
+
+                ssh_creds = _capture_ssh_credentials(connection_socket, bot_ip)
+                if ssh_creds and bear_storage is not None:
+                    bear_storage.login = ssh_creds
+                    logger.info(
+                        'Captured SSH credentials from %s: %s',
+                        bot_ip,
+                        ssh_creds,
+                    )
+                # Send report AFTER credential capture so login field has real creds
+                if bear_storage is not None:
+                    handler._enrich_and_send(bear_storage, bot_ip)
+        else:
+            # HTTP request: response bytes only (report already queued in process_request)
+            connection_socket.sendall(
+                output_data if isinstance(output_data, bytes) else output_data.encode('iso-8859-1')
+            )
     except socket.error:
         pass
     finally:

--- a/manyfaced/handlers/http_handler.py
+++ b/manyfaced/handlers/http_handler.py
@@ -120,6 +120,7 @@ class HTTPHandler:
 
         Returns:
             Tuple of (response_bytes, BearStorage) so caller can update credentials after capture.
+            NOTE: Does NOT queue report — caller must send report AFTER credential capture.
         """
         client = protocol_info.get('client', '')
         version = protocol_info.get('version', '')
@@ -142,7 +143,8 @@ class HTTPHandler:
             SSH_CLIENT,
             settings.HIVELOGIN,
         )
-        self._enrich_and_send(bs, bot_ip)
+        # NOTE: Do NOT call _enrich_and_send() here — credential capture happens
+        # after this returns. The caller must send the report AFTER updating bs.login.
         return banner.encode('utf-8'), bs
 
     def _handle_non_http_probe(

--- a/test/test_http_handler.py
+++ b/test/test_http_handler.py
@@ -448,7 +448,7 @@ class TestSSHEnrichment:
         return HTTPHandler(args, update_event)
 
     def test_ssh_probe_enriched_with_dns_and_geo(self, handler):
-        """SSH probe should produce a record with bot_dns_name/bot_country/bot_continent populated."""
+        """SSH probe should produce a record that gets enriched when _enrich_and_send is called."""
         from manyfaced.common.status import SSH_CLIENT
 
         mock_bs = MagicMock()
@@ -463,6 +463,7 @@ class TestSSHEnrichment:
             )
 
         # Should get SSH banner response (handle_request returns tuple for SSH)
+        bear_storage = None
         if isinstance(output, tuple):
             response_bytes, bear_storage = output
         else:
@@ -475,6 +476,9 @@ class TestSSHEnrichment:
         call_args = MockBS.call_args
         assert call_args[0][0] == '1.2.3.4'  # bot_ip
         assert call_args[0][4] == SSH_CLIENT  # detected_id
+
+        # Now simulate what the caller does: call _enrich_and_send after credential capture
+        handler._enrich_and_send(bear_storage, '1.2.3.4')
 
         # Verify enrichment methods were called on the BearStorage instance
         mock_bs.resolve_dns_name.assert_called_once_with('1.2.3.4', timeout=1.0)
@@ -498,6 +502,7 @@ class TestSSHEnrichment:
             )
 
         # Should still get SSH banner response (no crash)
+        bear_storage = None
         if isinstance(output, tuple):
             response_bytes, bear_storage = output
         else:
@@ -506,7 +511,8 @@ class TestSSHEnrichment:
         assert isinstance(response_bytes, bytes)
         assert response_bytes.startswith(b'SSH-2.0')
 
-        # resolve_geo should still be called even after DNS failure
+        # resolve_geo should still be called even after DNS failure (via _enrich_and_send)
+        handler._enrich_and_send(bear_storage, '1.2.3.4')
         mock_bs.resolve_geo.assert_called_once_with('1.2.3.4', timeout=2.0)
 
 


### PR DESCRIPTION
## Problem

SSH credentials were never being captured in the database. All SSH records had empty login field or sensor ID (DO-HP-DOHP) instead of actual captured credentials.

### Root Cause

The report was queued by _enrich_and_send() inside _handle_ssh_probe() BEFORE SSH credential capture happened:
1. handle_request() → _handle_ssh_probe() → creates BearStorage → queues report → returns banner
2. Caller sends response to bot  
3. Caller captures SSH credentials from socket (too late — report already sent)

### Fix

- Remove _enrich_and_send() call from _handle_ssh_probe() 
- Both callers (client.py and server_factory.py) now send the report AFTER capturing SSH credentials
- This ensures the login field contains real captured credentials (user=..., pass=...)

## Changes

- manyfaced/handlers/http_handler.py: Removed _enrich_and_send() from _handle_ssh_probe()
- manyfaced/client/server_factory.py: Handle tuple return type, send report after SSH credential capture
- manyfaced/client/client.py: Send report after SSH credential capture (single-port path)
- test/test_http_handler.py: Updated tests to reflect new flow

## Testing

- All 438 tests pass
- Ruff lint/format clean