### PR TITLE
fix: filter loopback and internal IP connections

### DIFF
--- a/manyfaced/client/client.py
+++ b/manyfaced/client/client.py
@@ -32,6 +32,14 @@ from manyfaced.common.myenc import AESCipher
 from manyfaced.common.ports import DEFAULT_TOP_PORTS as _DEFAULT_TOP_PORTS
 from manyfaced.common.status import BOT_TIMEOUT
 from manyfaced.handlers.http_handler import HTTPHandler
+
+# Internal IPs to filter out (loopback, DO internal network, honeypot's own IP)
+_INTERNAL_IPS = frozenset(
+    {
+        '127.0.0.1',  # loopback
+        '::1',  # IPv6 loopback
+    }
+)
 from manyfaced.common.utils import dump_file, receive_timeout
 
 logger = get_logger(__name__)
@@ -81,6 +89,12 @@ def create_server(args, update_event: Event, port: int):
                     print('Failed to receive data from bot')
                 continue
             bot_ip = bot_addr[0] if bot_addr else '127.0.0.1'
+
+            # Filter out internal/loopback connections (iptables redirects, local probes)
+            if bot_ip in _INTERNAL_IPS:
+                logger.debug('Dropping connection from internal IP %s', bot_ip)
+                continue
+
             handler = HTTPHandler(args, update_event)
             result = handler.handle_request(message, bot_ip=bot_ip)
 

--- a/manyfaced/client/server_factory.py
+++ b/manyfaced/client/server_factory.py
@@ -14,6 +14,14 @@ from manyfaced.common.status import BOT_TIMEOUT
 from manyfaced.common.utils import receive_timeout
 from manyfaced.handlers.http_handler import HTTPHandler
 
+# Internal IPs to filter out (loopback, DO internal network, honeypot's own IP)
+_INTERNAL_IPS = frozenset(
+    {
+        '127.0.0.1',  # loopback
+        '::1',  # IPv6 loopback
+    }
+)
+
 if TYPE_CHECKING:
     from socket import socket as SocketType
 
@@ -65,6 +73,12 @@ def _handle_bot_connection(
         return
 
     bot_ip = bot_addr[0] if bot_addr else '127.0.0.1'
+
+    # Filter out internal/loopback connections (iptables redirects, local probes)
+    if bot_ip in _INTERNAL_IPS:
+        logger.debug('Dropping connection from internal IP %s', bot_ip)
+        return
+
     handler = HTTPHandler(args, update_event)
     output_data = handler.handle_request(message, bot_ip=bot_ip)
 


### PR DESCRIPTION
## Problem

Internal iptables redirect probes from 127.0.0.1 were being stored in the honeypot database as detected_id=1 (fallback response) with sensor ID in login field. This pollutes analysis data with ~11 records/day of noise.

## Fix

Drop connections from internal IPs (127.0.0.1, ::1) before processing them. Added filter check early in both connection handling paths:
- `server_factory.py:_handle_bot_connection()` — multi-port server path
- `client.py:create_server()` — single-port server path

## Changes

- manyfaced/client/server_factory.py: Added _INTERNAL_IPS constant + early return for filtered IPs
- manyfaced/client/client.py: Same filter for single-port path