### PR TITLE
fix: BaseHandler.process_request_safe() now calls process_request() instead of no-op _common_processing()

### DIFF
--- a/manyfaced/handlers/base_handler.py
+++ b/manyfaced/handlers/base_handler.py
@@ -103,12 +103,17 @@ class BaseHandler(abc.ABC):
         """Common processing logic. Override in subclasses as needed."""
         pass
 
-    def process_request_safe(self, data: dict[str, Any]) -> Any:
-        """Wrapper that catches exceptions during processing."""
+    def process_request_safe(self, data: dict[str, Any]) -> Any | None:
+        """Wrapper that catches exceptions during processing and logs them properly.
+
+        Calls the abstract process_request() method with error handling.
+        Returns None if an exception occurs (prevents crashes in production).
+        """
         try:
-            self._common_processing(data)
+            return self.process_request(data)
         except Exception as e:
-            print(f'Error processing request: {e}')
+            logger.error('Error processing request: %s', e, exc_info=True)
+            return None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix audit #5: `process_request_safe()` was calling `_common_processing()` (a no-op `pass`) instead of the abstract `process_request()` method.

### Changes
- `process_request_safe()` now calls `self.process_request(data)` and returns its result
- Replace `print(f'Error processing request: {e}')` with proper `logger.error('Error processing request: %s', e, exc_info=True)`
- Return `None` on exception to prevent crashes in production

### Impact
This fixes a structural bug where the safe wrapper was doing nothing useful and swallowing errors silently. Any code that calls `process_request_safe()` will now actually process requests with proper error handling.