### PR TITLE
fix: Router.routes property now has correct docstring and routes_count added

### DIFF
--- a/manyfaced/handlers/router.py
+++ b/manyfaced/handlers/router.py
@@ -177,8 +177,13 @@ class Router:
         return 'no match'
 
     @property
-    def routes(self) -> list[Route]:
+    def routes_count(self) -> int:
         """Number of routes in the table."""
+        return len(self._routes)
+
+    @property
+    def routes(self) -> list[Route]:
+        """The ordered list of Route objects."""
         return self._routes
 
 


### PR DESCRIPTION
## Summary

Fix audit #6: `Router.routes` property docstring said 'Number of routes in the table' but it returned the list itself, which is misleading.

### Changes
- Add new `routes_count` property that returns `len(self._routes)` as originally documented
- Update `routes` property docstring to accurately describe it returns the list