### PR TITLE
fix: consolidate config resolution into single module (audit #9)

### DIFF
--- a/manyfaced/common/config.py
+++ b/manyfaced/common/config.py
@@ -174,23 +174,35 @@ class Config:
         prefix = env_prefix()
 
         return Config(
-            HONEYPORT=int(resolve_setting('honeyport', _DEFAULT_HONEYPORT, 'honeypot', toml, prefix)),
+            HONEYPORT=int(
+                resolve_setting('honeyport', _DEFAULT_HONEYPORT, 'honeypot', toml, prefix)
+            ),  # type: ignore[arg-type]
             HONEYFOLDER=str(
                 resolve_setting('honeyfolder', _DEFAULT_HONEYFOLDER, 'honeypot', toml, prefix)
             ),
-            HIVEHOST=str(resolve_setting('hivehost', _DEFAULT_HIVEHOST, 'hive', toml, prefix)),
-            HIVEPORT=int(resolve_setting('hiveport', _DEFAULT_HIVEPORT, 'hive', toml, prefix)),
-            HIVELOGIN=str(resolve_setting('hivelogin', _DEFAULT_HIVELOGIN, 'hive', toml, prefix)),
-            HIVEPASS=str(resolve_setting('hivepass', _DEFAULT_HIVEPASS or '', 'hive', toml, prefix)),
-            DB_BACKEND=str(resolve_setting('backend', _DEFAULT_DB_BACKEND, 'database', toml, prefix)),
+            HIVEHOST=str(resolve_setting('hivehost', _DEFAULT_HIVEHOST, 'hive', toml, prefix)),  # type: ignore[arg-type]
+            HIVEPORT=int(resolve_setting('hiveport', _DEFAULT_HIVEPORT, 'hive', toml, prefix)),  # type: ignore[arg-type]
+            HIVELOGIN=str(resolve_setting('hivelogin', _DEFAULT_HIVELOGIN, 'hive', toml, prefix)),  # type: ignore[arg-type]
+            HIVEPASS=str(
+                resolve_setting('hivepass', _DEFAULT_HIVEPASS or '', 'hive', toml, prefix)
+            ),  # type: ignore[arg-type]
+            DB_BACKEND=str(
+                resolve_setting('backend', _DEFAULT_DB_BACKEND, 'database', toml, prefix)
+            ),  # type: ignore[arg-type]
             DB_BACKENDS=tuple(
                 resolve_setting('backends', _DEFAULT_DB_BACKENDS, 'database', toml, prefix)  # type: ignore[arg-type]
             ),
-            DB_PATH=str(resolve_setting('path', _DEFAULT_DB_PATH, 'database', toml, prefix)),
-            DB_PG_HOST=str(resolve_setting('pg_host', _DEFAULT_DB_PG_HOST, 'database', toml, prefix)),
-            DB_PG_PORT=int(resolve_setting('pg_port', _DEFAULT_DB_PG_PORT, 'database', toml, prefix)),
-            DB_PG_DB=str(resolve_setting('pg_db', _DEFAULT_DB_PG_DB, 'database', toml, prefix)),
-            DB_PG_USER=str(resolve_setting('pg_user', _DEFAULT_DB_PG_USER, 'database', toml, prefix)),
+            DB_PATH=str(resolve_setting('path', _DEFAULT_DB_PATH, 'database', toml, prefix)),  # type: ignore[arg-type]
+            DB_PG_HOST=str(
+                resolve_setting('pg_host', _DEFAULT_DB_PG_HOST, 'database', toml, prefix)
+            ),  # type: ignore[arg-type]
+            DB_PG_PORT=int(
+                resolve_setting('pg_port', _DEFAULT_DB_PG_PORT, 'database', toml, prefix)
+            ),  # type: ignore[arg-type]
+            DB_PG_DB=str(resolve_setting('pg_db', _DEFAULT_DB_PG_DB, 'database', toml, prefix)),  # type: ignore[arg-type]
+            DB_PG_USER=str(
+                resolve_setting('pg_user', _DEFAULT_DB_PG_USER, 'database', toml, prefix)
+            ),  # type: ignore[arg-type]
             DB_PG_PASSWORD=str(
                 resolve_setting('pg_password', _DEFAULT_DB_PG_PASSWORD, 'database', toml, prefix)
             ),
@@ -205,16 +217,16 @@ class Config:
                         prefix,
                     )
                     or {}
-                ).items()
+                ).items()  # type: ignore[union-attr]
             },
-            HONEY_PORT_MODE=str(resolve_setting('port_mode', 'single', 'honeypot', toml, prefix)),
-            HONEY_TOP_PORTS=str(resolve_setting('top_ports', '', 'honeypot', toml, prefix)),
+            HONEY_PORT_MODE=str(resolve_setting('port_mode', 'single', 'honeypot', toml, prefix)),  # type: ignore[arg-type]
+            HONEY_TOP_PORTS=str(resolve_setting('top_ports', '', 'honeypot', toml, prefix)),  # type: ignore[arg-type]
             DEFAULT_KEY=str(
                 resolve_setting('default_key', _DEFAULT_DEFAULT_KEY or '', 'security', toml, prefix)
             ),
-            LOG_FILE=str(resolve_setting('file', _DEFAULT_LOG_FILE, 'logging', toml, prefix)),
-            DUMP_FILE=str(resolve_setting('dump_file', _DEFAULT_DUMP_FILE, 'dump', toml, prefix)),
-            LOCKFILE=str(resolve_setting('lockfile', _DEFAULT_LOCKFILE, 'lockfile', toml, prefix)),
+            LOG_FILE=str(resolve_setting('file', _DEFAULT_LOG_FILE, 'logging', toml, prefix)),  # type: ignore[arg-type]
+            DUMP_FILE=str(resolve_setting('dump_file', _DEFAULT_DUMP_FILE, 'dump', toml, prefix)),  # type: ignore[arg-type]
+            LOCKFILE=str(resolve_setting('lockfile', _DEFAULT_LOCKFILE, 'lockfile', toml, prefix)),  # type: ignore[arg-type]
         )
 
     def generate_config_file(self, path: Path | str | None = None) -> Path:

--- a/manyfaced/common/config.py
+++ b/manyfaced/common/config.py
@@ -122,68 +122,7 @@ def _load_toml(path: Path) -> dict[str, Any]:
     return result
 
 
-def _env_prefix() -> str:
-    return 'HONEY_'
-
-
-# ── helpers ─────────────────────────────────────────────────────────────────
-
-
-def _resolve(
-    name: str, default: Any, section: str, toml: dict[str, Any] | None, env_prefix: str
-) -> Any:
-    """Resolve a config value from env → TOML → default.
-
-    Returns the resolved value with the same type as *default*.
-    """
-    toml_key = f'{section}.{name}'
-    env_key = f'{env_prefix}{name.upper()}'
-
-    # 3 – env var (highest priority)
-    env_val = os.environ.get(env_key)
-    if env_val is not None:
-        # Coerce types based on the default's type
-        if isinstance(default, int):
-            return int(env_val)  # type: ignore[return-value]
-        if isinstance(default, bool):
-            return env_val.lower() in ('1', 'true', 'yes')  # type: ignore[return-value]
-        if isinstance(default, dict):
-            # semicolon-separated key:value pairs → dict[str, str]
-            d: dict[str, str] = {}
-            for pair in (env_val or '').split(';'):
-                pair = pair.strip()
-                if ':' in pair:
-                    k, v = pair.split(':', 1)
-                    d[k.strip()] = v.strip()
-            return d or default  # type: ignore[return-value]
-        if isinstance(default, (list, tuple)):
-            result = [v.strip() for v in env_val.split(';') if v.strip()]
-            return result or default  # type: ignore[return-value]
-        return env_val
-
-    # 2 – TOML
-    if toml and toml_key in toml:
-        val = toml[toml_key]
-        if isinstance(default, int) and isinstance(val, str):
-            return int(val)  # type: ignore[return-value]
-        if isinstance(default, dict) and isinstance(val, str):
-            # semicolon-separated key:value pairs (same as env var handling)
-            tomld: dict[str, str] = {}
-            for pair in (val or '').split(';'):
-                pair = pair.strip()
-                if ':' in pair:
-                    k, v = pair.split(':', 1)
-                    tomld[k.strip()] = v.strip()
-            return tomld or default  # type: ignore[return-value]
-        return val
-
-    # 1 – default (lowest priority)
-    if default is None:
-        return ''  # type: ignore[return-value]
-    return default
-
-
-# ── Config singleton (lazy) ─────────────────────────────────────────────────
+from manyfaced.common.config_resolver import env_prefix, resolve_setting  # noqa: E402
 
 
 @dataclass(frozen=True)
@@ -232,33 +171,33 @@ class Config:
         if config_path:
             toml = _load_toml(config_path)
 
-        prefix = _env_prefix()
+        prefix = env_prefix()
 
         return Config(
-            HONEYPORT=int(_resolve('honeyport', _DEFAULT_HONEYPORT, 'honeypot', toml, prefix)),
+            HONEYPORT=int(resolve_setting('honeyport', _DEFAULT_HONEYPORT, 'honeypot', toml, prefix)),
             HONEYFOLDER=str(
-                _resolve('honeyfolder', _DEFAULT_HONEYFOLDER, 'honeypot', toml, prefix)
+                resolve_setting('honeyfolder', _DEFAULT_HONEYFOLDER, 'honeypot', toml, prefix)
             ),
-            HIVEHOST=str(_resolve('hivehost', _DEFAULT_HIVEHOST, 'hive', toml, prefix)),
-            HIVEPORT=int(_resolve('hiveport', _DEFAULT_HIVEPORT, 'hive', toml, prefix)),
-            HIVELOGIN=str(_resolve('hivelogin', _DEFAULT_HIVELOGIN, 'hive', toml, prefix)),
-            HIVEPASS=str(_resolve('hivepass', _DEFAULT_HIVEPASS or '', 'hive', toml, prefix)),
-            DB_BACKEND=str(_resolve('backend', _DEFAULT_DB_BACKEND, 'database', toml, prefix)),
+            HIVEHOST=str(resolve_setting('hivehost', _DEFAULT_HIVEHOST, 'hive', toml, prefix)),
+            HIVEPORT=int(resolve_setting('hiveport', _DEFAULT_HIVEPORT, 'hive', toml, prefix)),
+            HIVELOGIN=str(resolve_setting('hivelogin', _DEFAULT_HIVELOGIN, 'hive', toml, prefix)),
+            HIVEPASS=str(resolve_setting('hivepass', _DEFAULT_HIVEPASS or '', 'hive', toml, prefix)),
+            DB_BACKEND=str(resolve_setting('backend', _DEFAULT_DB_BACKEND, 'database', toml, prefix)),
             DB_BACKENDS=tuple(
-                _resolve('backends', _DEFAULT_DB_BACKENDS, 'database', toml, prefix)  # type: ignore[arg-type]
+                resolve_setting('backends', _DEFAULT_DB_BACKENDS, 'database', toml, prefix)  # type: ignore[arg-type]
             ),
-            DB_PATH=str(_resolve('path', _DEFAULT_DB_PATH, 'database', toml, prefix)),
-            DB_PG_HOST=str(_resolve('pg_host', _DEFAULT_DB_PG_HOST, 'database', toml, prefix)),
-            DB_PG_PORT=int(_resolve('pg_port', _DEFAULT_DB_PG_PORT, 'database', toml, prefix)),
-            DB_PG_DB=str(_resolve('pg_db', _DEFAULT_DB_PG_DB, 'database', toml, prefix)),
-            DB_PG_USER=str(_resolve('pg_user', _DEFAULT_DB_PG_USER, 'database', toml, prefix)),
+            DB_PATH=str(resolve_setting('path', _DEFAULT_DB_PATH, 'database', toml, prefix)),
+            DB_PG_HOST=str(resolve_setting('pg_host', _DEFAULT_DB_PG_HOST, 'database', toml, prefix)),
+            DB_PG_PORT=int(resolve_setting('pg_port', _DEFAULT_DB_PG_PORT, 'database', toml, prefix)),
+            DB_PG_DB=str(resolve_setting('pg_db', _DEFAULT_DB_PG_DB, 'database', toml, prefix)),
+            DB_PG_USER=str(resolve_setting('pg_user', _DEFAULT_DB_PG_USER, 'database', toml, prefix)),
             DB_PG_PASSWORD=str(
-                _resolve('pg_password', _DEFAULT_DB_PG_PASSWORD, 'database', toml, prefix)
+                resolve_setting('pg_password', _DEFAULT_DB_PG_PASSWORD, 'database', toml, prefix)
             ),
             AUTHORIZED_BEES={
                 str(k): str(v)
                 for k, v in (
-                    _resolve(
+                    resolve_setting(
                         'authorized_bees',
                         _DEFAULT_AUTHORIZED_BEES_DEFAULTS,
                         'security',
@@ -268,14 +207,14 @@ class Config:
                     or {}
                 ).items()
             },
-            HONEY_PORT_MODE=str(_resolve('port_mode', 'single', 'honeypot', toml, prefix)),
-            HONEY_TOP_PORTS=str(_resolve('top_ports', '', 'honeypot', toml, prefix)),
+            HONEY_PORT_MODE=str(resolve_setting('port_mode', 'single', 'honeypot', toml, prefix)),
+            HONEY_TOP_PORTS=str(resolve_setting('top_ports', '', 'honeypot', toml, prefix)),
             DEFAULT_KEY=str(
-                _resolve('default_key', _DEFAULT_DEFAULT_KEY or '', 'security', toml, prefix)
+                resolve_setting('default_key', _DEFAULT_DEFAULT_KEY or '', 'security', toml, prefix)
             ),
-            LOG_FILE=str(_resolve('file', _DEFAULT_LOG_FILE, 'logging', toml, prefix)),
-            DUMP_FILE=str(_resolve('dump_file', _DEFAULT_DUMP_FILE, 'dump', toml, prefix)),
-            LOCKFILE=str(_resolve('lockfile', _DEFAULT_LOCKFILE, 'lockfile', toml, prefix)),
+            LOG_FILE=str(resolve_setting('file', _DEFAULT_LOG_FILE, 'logging', toml, prefix)),
+            DUMP_FILE=str(resolve_setting('dump_file', _DEFAULT_DUMP_FILE, 'dump', toml, prefix)),
+            LOCKFILE=str(resolve_setting('lockfile', _DEFAULT_LOCKFILE, 'lockfile', toml, prefix)),
         )
 
     def generate_config_file(self, path: Path | str | None = None) -> Path:

--- a/manyfaced/common/config_resolver.py
+++ b/manyfaced/common/config_resolver.py
@@ -11,6 +11,7 @@ This module is imported by manyfaced.common.config to keep that module lean.
 from __future__ import annotations
 
 import os
+from typing import Any
 
 
 def _parse_dict_env(env_val: str) -> dict[str, str]:
@@ -24,7 +25,7 @@ def _parse_dict_env(env_val: str) -> dict[str, str]:
     return d
 
 
-def _parse_dict_toml(val) -> dict[str, str]:
+def _parse_dict_toml(val: Any) -> dict[str, str] | Any:
     """Parse a TOML string value (semicolon-separated ``key:value``) into a dict."""
     if not isinstance(val, str):
         return val  # already a dict from TOML
@@ -39,11 +40,11 @@ def _parse_dict_toml(val) -> dict[str, str]:
 
 def resolve_setting(
     name: str,
-    default,
+    default: Any,
     section: str,
-    toml_dict: dict | None,
+    toml_dict: dict[str, Any] | None,
     env_prefix: str,
-):
+) -> Any:
     """Resolve a single configuration setting with TOML → env var precedence.
 
     Resolution order (highest priority first):

--- a/test/test_config/conftest.py
+++ b/test/test_config/conftest.py
@@ -17,7 +17,8 @@ sys.modules['geoip'] = geoip_mock
 sys.modules['geoip.geolite2'] = geoip_mock.geolite2
 sys.modules['GeoIP'] = MagicMock()
 
-from manyfaced.common.config import Config, _load_toml, _resolve, _env_prefix
+from manyfaced.common.config import Config, _load_toml
+from manyfaced.common.config_resolver import resolve_setting as _resolve, env_prefix as _env_prefix
 
 
 def _write_toml(tmp_path: Path, content: str) -> Path:


### PR DESCRIPTION
## Summary

Fix audit #9: Config resolution logic existed in two places —  private  and  public . These were near-exact duplicates.

### Changes
- Removed duplicate  function from config.py (61 lines)
- Import  and  from  instead
- Removed unused  function
- All 21 calls updated to use the canonical 