### PR TITLE
fix: run tests and typecheck before deploy on push-to-master (audit #13)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,8 +50,8 @@ jobs:
         run: ruff check .
 
   test:
-    # Run on PRs for validation; skipped on push-to-master (deploy is fast-path).
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    # Run on PRs, push-to-master, and manual dispatch for validation.
+    if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
@@ -74,8 +74,8 @@ jobs:
         run: pytest -v --tb=short
 
   typecheck:
-    # Run on PRs for validation; skipped on push-to-master (deploy is fast-path).
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    # Run on PRs, push-to-master, and manual dispatch for validation.
+    if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     name: Typecheck (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
@@ -107,9 +107,8 @@ jobs:
         uses: raven-actions/actionlint@v2
 
   deploy:
-    needs: [lint, actionlint]
+    needs: [lint, actionlint, test, typecheck]
     # Only deploy on push-to-master and manual dispatch; skip on PRs.
-    # Tests/typecheck are skipped on master — they already pass via PR CI.
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     environment: production


### PR DESCRIPTION
## Summary

Fix audit #13: CI deploys master without running tests.

### Changes
- Added `push` event trigger to both `test` and `typecheck` jobs in `.github/workflows/deploy.yml`
- Added `test` and `typecheck` to the `deploy` job's `needs` list
- Now deployment waits for all CI checks (lint, actionlint, test, typecheck) to pass before deploying

### Impact
Previously, a push to master would skip tests/typecheck entirely and deploy directly. This meant broken code could reach production without any automated validation. Now every master push runs the full CI suite first.