### PR TITLE
fix: align ruff versions and remove formatter exclusions (audit #14)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.0
+    rev: v0.15.13
     hooks:
       - id: ruff-check
         args: ["--fix"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,14 +43,6 @@ line-length = 100
 [tool.ruff.format]
 quote-style = "single"
 indent-style = "space"
-# Workaround for ruff bug (0.15.x): formatter converts valid Python 3
-# `except (A, B):` to invalid `except A, B:` syntax. These files use
-# multi-exception tuples and must be excluded from auto-formatting.
-exclude = [
-    "manyfaced/db/storage.py",
-    "manyfaced/mfh.py",
-    "manyfaced/common/bearstorage.py",
-]
 
 [tool.ruff.lint]
 ignore = [


### PR DESCRIPTION
## Summary

Fix audit #14: Ruff version skew and unnecessary formatter exclusions.

### Changes
- Updated `.pre-commit-config.yaml` from `v0.15.0` to `v0.15.13` to match `pyproject.toml` dev extra
- Removed `[tool.ruff.format].exclude` list that excluded 3 files from formatting:
  - `manyfaced/db/storage.py`
  - `manyfaced/mfh.py`
  - `manyfaced/common/bearstorage.py`

### Rationale
The comment cited a ruff bug (0.15.x) where the formatter converted valid Python 3 `except (A, B):` to invalid syntax. This bug was fixed in earlier 0.15.x releases. Verified that all three files format correctly with ruff 0.15.13 and the full project passes `ruff format --check .` (105 files).