### PR TITLE
fix: remove pytest.ini override, unify pytest config (issue #116)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ ignore = [
 "test/*" = ["E402", "F401", "F841"]
 
 [tool.pytest.ini_options]
-addopts = "--cov=manyfaced --cov-report=term-missing --cov-report=xml --cov-fail-under=76"
+addopts = "-v --cov=manyfaced --cov-report=term-missing --cov-report=xml --cov-fail-under=76"
 testpaths = ["test"]
 
 [tool.interrogate]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-addopts = -v --cov=manyfaced --cov-report=term-missing --cov-report=xml --cov-fail-under=70
-testpaths = test


### PR DESCRIPTION
## Summary

Remove pytest.ini which was overriding pyproject.toml's `[tool.pytest.ini_options]`, lowering the coverage gate from 76% to 70%.

### Changes
- **Delete `pytest.ini`** — it was duplicating and overriding pyproject.toml config, specifically lowering `--cov-fail-under` from 76% (documented) to 70%
- **Add `-v` flag back** to pyproject.toml's `addopts` for local dev verbosity that pytest.ini had

### Result
Single source of truth: `pyproject.toml` is now the only pytest config. Coverage gate matches documentation at 76%.
