### PR TITLE
fix: register WebDAVHandler in router (issue #119)

### DIFF
--- a/manyfaced/handlers/routes/__init__.py
+++ b/manyfaced/handlers/routes/__init__.py
@@ -11,8 +11,6 @@ Overlap resolution (deliberate ordering):
 
 ConfigDisclosure's patterns all migrate intact — they simply lose the above
 three paths because higher-priority routes are listed first.
-
-WebDAVHandler is NOT registered here (separate brief).
 """
 
 from __future__ import annotations
@@ -44,10 +42,11 @@ from manyfaced.handlers.routes.routes_phpmyadmin import (
     ROUTES as _phpmyadmin_routes,  # noqa: E402
 )
 from manyfaced.handlers.routes.routes_tomcat import ROUTES as _tomcat_routes  # noqa: E402
+from manyfaced.handlers.routes.routes_webdav import ROUTES as _webdav_routes  # noqa: E402
 from manyfaced.handlers.routes.routes_wordpress import ROUTES as _wordpress_routes  # noqa: E402
 
 # Concatenate in the original order: WordPress → phpMyAdmin → Jenkins → Tomcat →
-# Drupal → cPanel → Bitrix → ConfigDisclosure → catch-all
+# Drupal → cPanel → Bitrix → WebDAV → ConfigDisclosure → catch-all
 ROUTES: list[Route] = (
     list(_wordpress_routes)
     + list(_phpmyadmin_routes)
@@ -56,6 +55,7 @@ ROUTES: list[Route] = (
     + list(_drupal_routes)
     + list(_cpanel_routes)
     + list(_bitrix_routes)
+    + list(_webdav_routes)
     + list(_config_disclosure_routes)
     + [Route(Any(), _generic(), 4294967294, 'catchall_monster_page')]
 )

--- a/manyfaced/handlers/routes/routes_webdav.py
+++ b/manyfaced/handlers/routes/routes_webdav.py
@@ -1,0 +1,32 @@
+"""WebDAV routes — WebDAV-specific endpoints."""
+
+from __future__ import annotations
+
+from manyfaced.handlers.router import PathExact, PathPrefix, Route
+
+from manyfaced.common.status import WEBDAV_HTTP
+
+
+def _webdav() -> type:
+    from manyfaced.handlers.webdav_handler import WebDAVHandler
+
+    return WebDAVHandler
+
+
+ROUTES: list[Route] = [
+    # ---- WebDAV (canonical WebDAV endpoints) -------------------------------
+    Route(PathExact('/webdav'), _webdav(), WEBDAV_HTTP, 'webdav_root'),
+    Route(PathPrefix('/webdav/'), _webdav(), WEBDAV_HTTP, 'webdav_root_slash'),
+    Route(PathExact('/dav'), _webdav(), WEBDAV_HTTP, 'webdav_dav'),
+    Route(PathPrefix('/dav/'), _webdav(), WEBDAV_HTTP, 'webdav_dav_slash'),
+    Route(PathExact('/remote.php'), _webdav(), WEBDAV_HTTP, 'webdav_remote_php'),
+    Route(PathPrefix('/remote.php/'), _webdav(), WEBDAV_HTTP, 'webdav_remote_php_slash'),
+    Route(PathExact('/owncloud'), _webdav(), WEBDAV_HTTP, 'webdav_owncloud'),
+    Route(PathPrefix('/owncloud/'), _webdav(), WEBDAV_HTTP, 'webdav_owncloud_slash'),
+    Route(PathExact('/caldav'), _webdav(), WEBDAV_HTTP, 'webdav_caldav'),
+    Route(PathPrefix('/caldav/'), _webdav(), WEBDAV_HTTP, 'webdav_caldav_slash'),
+    Route(PathExact('/carddav'), _webdav(), WEBDAV_HTTP, 'webdav_carddav'),
+    Route(PathPrefix('/carddav/'), _webdav(), WEBDAV_HTTP, 'webdav_carddav_slash'),
+    Route(PathExact('/web'), _webdav(), WEBDAV_HTTP, 'webdav_web'),
+    Route(PathPrefix('/web/'), _webdav(), WEBDAV_HTTP, 'webdav_web_slash'),
+]


### PR DESCRIPTION
## Summary

Fix WebDAVHandler being fully implemented but never registered in the route table.

### Added
`manyfaced/handlers/routes/routes_webdav.py` — 14 routes covering common WebDAV endpoints:
- `/webdav`, `/dav` — canonical WebDAV paths
- `/remote.php`, `/owncloud` — Nextcloud/OCS endpoints  
- `/caldav`, `/carddav` — CalDAV/CardDAV sync endpoints
- `/web` — common WebDAV alias

### Changes to `routes/__init__.py`
- Import and concatenate webdav routes into the ROUTES list (after Bitrix, before ConfigDisclosure)
- Removed stale comment "WebDAVHandler is NOT registered here (separate brief)"

### Overlap handling
- Drupal still wins `/files` (registered earlier in route table)
- ConfigDisclosure patterns don't steal WebDAV paths (lower priority)