### PR TITLE
fix: add .claude/ and .cursor/ to .gitignore (issue #120)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,7 @@ prod-backup/
 
 # Local CLI binaries (downloaded for local pre-checks)
 actionlint
+
+# AI coding assistant directories
+.claude/
+.cursor/


### PR DESCRIPTION
## Summary

Add AI coding assistant directories to `.gitignore` per issue #120.

### Added
- `.claude/` — Claude Code project settings directory
- `.cursor/` — Cursor IDE project settings directory