### PR TITLE
fix: align dependency docs to geoip2 (issue #114)

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,9 +361,10 @@ Messages between client and server use AES-256-CBC with:
 | Package | Purpose |
 |------|-------|
 | cryptography>=41.0 | AES-256-CBC encryption for client-server comms |
-| python-geoip | IP geolocation for bot attribution |
-| python-geoip-geolite2 | GeoLite2 database for geolocation |
-| pytest (dev) | Testing framework |
+| geoip2 (optional) | IP geolocation via MaxMind GeoLite2 .mmdb database |
+| pytest + pytest-cov (dev) | Testing framework with coverage reporting |
+| basedpyright (dev) | Static type checking |
+| ruff==0.15.13 (dev) | Linting and formatting |
 
 Install all deps in one command:
 

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -258,7 +258,7 @@ test/
 
 3. **AUTHORIZED_BEANS** — In server mode, this dict determines which bots are authorized. If empty/no entries match, decryption will fail.
 
-4. **geoip2 dependency** — The `python-geoip-geolite2` package requires a GeoLite2 database to be installed separately. Without it, country/continent fields will be empty.
+4. **geoip2 dependency** — The `geoip2` package requires a MaxMind GeoLite2 `.mmdb` database to be installed separately. Without it, country/continent fields will be empty.
 
 ## Handler Coverage Analysis
 


### PR DESCRIPTION
## Summary

Align all dependency documentation to `geoip2` package, removing stale `python-geoip` references.

### Changes
- **README.md Dependencies table**: Replaced `python-geoip` + `python-geoip-geolite2` with `geoip2 (optional)` referencing MaxMind GeoLite2 `.mmdb` database format; added missing dev deps (`pytest-cov`, `basedpyright`, `ruff==0.15.13`)
- **docs/DEVELOPER.md security notes**: Updated geoip2 dependency note to reference correct package name and `.mmdb` format