### PR TITLE
fix: bound BotProfile memory with LRU cache (issue #111)

### DIFF
--- a/manyfaced/handlers/base_handler.py
+++ b/manyfaced/handlers/base_handler.py
@@ -20,6 +20,7 @@ import json
 import logging
 import threading
 from abc import abstractmethod
+from collections import OrderedDict
 from typing import Any
 
 from manyfaced.common.myenc import AESCipher
@@ -138,8 +139,12 @@ class HTTPHandlerBase(abc.ABC):
     # Detected ID value for this service
     DETECTED_ID: int = 1
 
+    # Maximum number of bot profiles per handler (LRU eviction when exceeded)
+    MAX_PROFILES: int = 1000
+
     def __init__(self) -> None:
-        self.bot_profiles: dict[str, BotProfile] = {}
+        # OrderedDict-based LRU cache — most recently used item is at the end
+        self.bot_profiles: OrderedDict[str, BotProfile] = OrderedDict()
         self._lock = threading.RLock()
         self._response_count: int = 0
 
@@ -164,18 +169,38 @@ class HTTPHandlerBase(abc.ABC):
         """
 
     def get_or_create_profile(self, bot_ip: str) -> BotProfile:
-        """Get existing profile or create a new one for the bot."""
+        """Get existing profile or create a new one for the bot.
+
+        Uses an LRU cache with a configurable max size (MAX_PROFILES). When the
+        cache is full, the least-recently-used profile is evicted to prevent
+        unbounded memory growth.
+        """
         with self._lock:
-            if bot_ip not in self.bot_profiles:
-                profile = BotProfile(bot_ip=bot_ip)
-                self.bot_profiles[bot_ip] = profile
+            if bot_ip in self.bot_profiles:
+                # Move to end (most recently used) — only for OrderedDict
+                if hasattr(self.bot_profiles, 'move_to_end'):
+                    self.bot_profiles.move_to_end(bot_ip)
+                return self.bot_profiles[bot_ip]
+
+            # Evict least-recently-used profile if at capacity
+            while len(self.bot_profiles) >= self.MAX_PROFILES:
+                evicted_ip, evicted_profile = self.bot_profiles.popitem(last=False)
                 logger.info(
-                    'Created new BotProfile for %s (session=%s, domain=%s)',
-                    bot_ip,
-                    profile.session_id,
+                    'Evicted LRU BotProfile for %s (domain=%s, cache_size=%d)',
+                    evicted_ip,
                     self.domain,
+                    len(self.bot_profiles),
                 )
-            return self.bot_profiles[bot_ip]
+
+            profile = BotProfile(bot_ip=bot_ip)
+            self.bot_profiles[bot_ip] = profile
+            logger.info(
+                'Created new BotProfile for %s (session=%s, domain=%s)',
+                bot_ip,
+                profile.session_id,
+                self.domain,
+            )
+            return profile
 
     def handle_login(
         self,
@@ -229,9 +254,17 @@ class HTTPHandlerBase(abc.ABC):
         return b'HTTP/1.1 302 Found\r\nLocation: /wp-admin/\r\n\r\n'
 
     def get_profile(self, bot_ip: str) -> BotProfile | None:
-        """Get the bot's profile, or None if not found."""
+        """Get the bot's profile, or None if not found.
+
+        Moves the profile to end (most recently used) for LRU tracking.
+        """
         with self._lock:
-            return self.bot_profiles.get(bot_ip)
+            if bot_ip in self.bot_profiles:
+                # Move to end (most recently used) — only for OrderedDict
+                if hasattr(self.bot_profiles, 'move_to_end'):
+                    self.bot_profiles.move_to_end(bot_ip)
+                return self.bot_profiles[bot_ip]
+            return None
 
     def get_all_profiles(self) -> list[BotProfile]:
         """Get all bot profiles."""

--- a/manyfaced/handlers/bot_profile.py
+++ b/manyfaced/handlers/bot_profile.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import threading
+from collections import OrderedDict
 from datetime import datetime, timezone
 from typing import Any
 
@@ -50,6 +51,12 @@ class BotProfile:
     The dialogue is the most valuable artifact – it captures the complete
     interaction with the attacker, including exploit attempts, scanning
     patterns, and any credentials submitted.
+
+    Memory bounds:
+        - Per-profile ``request_history`` and ``dialogue`` are capped at
+          ``MAX_HISTORY`` entries (oldest evicted on append).
+        - The handler-level profile cache uses an LRU with a configurable
+          max size; when full, the least-recently-used profile is discarded.
     """
 
     # Escalation levels
@@ -68,6 +75,10 @@ class BotProfile:
         COMPROMISE: 'compromised',
         DEEP_EXPLOIT: 'deep_exploiting',
     }
+
+    # Memory bounds — per-profile caps
+    MAX_HISTORY = 500  # request_history entries
+    MAX_DIALOGUE = 500  # dialogue entries
 
     def __init__(self, bot_ip: str) -> None:
         self.bot_ip = bot_ip
@@ -93,6 +104,9 @@ class BotProfile:
         """Record a request made by this bot."""
         with self._lock:
             self.request_history.append(request)
+            # Evict oldest entries to stay within bounds
+            while len(self.request_history) > self.MAX_HISTORY:
+                self.request_history.pop(0)
             self.last_updated = datetime.now(timezone.utc)
             self._analyze_request(request)
             # Extract metadata from first request
@@ -152,6 +166,9 @@ class BotProfile:
                 },
             }
             self.dialogue.append(dialogue_entry)
+            # Evict oldest entries to stay within bounds
+            while len(self.dialogue) > self.MAX_DIALOGUE:
+                self.dialogue.pop(0)
             logger.info(
                 'Recorded dialogue entry #%d for %s (path=%s, method=%s)',
                 dialogue_entry['sequence'],

--- a/test/test_http_handler.py
+++ b/test/test_http_handler.py
@@ -665,3 +665,120 @@ class TestNonHTTPEnrichment:
 
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])
+
+
+# ---------------------------------------------------------------------------
+# BotProfile Memory Bounds Tests (issue #111)
+# ---------------------------------------------------------------------------
+
+
+class TestBotProfileMemoryBounds:
+    """Tests for BotProfile memory bounds enforcement."""
+
+    def test_request_history_eviction(self):
+        """request_history should evict oldest entries when exceeding MAX_HISTORY."""
+        from manyfaced.handlers.bot_profile import BotProfile
+
+        profile = BotProfile(bot_ip='1.2.3.4')
+        # Fill beyond the cap
+        for i in range(profile.MAX_HISTORY + 10):
+            profile.record_request({'path': f'/path{i}', 'method': 'GET'})
+
+        assert len(profile.request_history) == profile.MAX_HISTORY
+        # Oldest entries should be evicted (first 10 missing)
+        paths = [r['path'] for r in profile.request_history]
+        assert paths[0] == '/path10'
+        assert paths[-1] == '/path509'
+
+    def test_dialogue_eviction(self):
+        """dialogue should evict oldest entries when exceeding MAX_DIALOGUE."""
+        from manyfaced.handlers.bot_profile import BotProfile
+
+        profile = BotProfile(bot_ip='5.6.7.8')
+        # Fill beyond the cap
+        for i in range(profile.MAX_DIALOGUE + 10):
+            profile.record_interaction(
+                request={'path': f'/dialogue{i}', 'method': 'GET', 'raw': ''},
+                response=b'HTTP/1.1 200 OK\r\n\r\n',
+                detected=1,
+            )
+
+        assert len(profile.dialogue) == profile.MAX_DIALOGUE
+        # Oldest entries should be evicted
+        paths = [d['request']['path'] for d in profile.dialogue]
+        assert paths[0] == '/dialogue10'
+        assert paths[-1] == '/dialogue509'
+
+
+class TestHandlerLRUCache:
+    """Tests for HTTPHandlerBase LRU bot_profiles cache (issue #111)."""
+
+    @pytest.fixture
+    def handler(self):
+        """Create a minimal GenericHandler instance."""
+        from manyfaced.handlers.generic_handler import GenericHandler
+
+        return GenericHandler()
+
+    def test_lru_eviction_on_capacity(self, handler):
+        """When MAX_PROFILES is exceeded, least-recently-used profile should be evicted."""
+        # Temporarily lower the cap for faster testing
+        original_max = handler.MAX_PROFILES
+        handler.MAX_PROFILES = 5
+
+        try:
+            # Create 7 profiles (exceeds capacity of 5)
+            for i in range(7):
+                handler.get_or_create_profile(f'10.0.0.{i}')
+
+            assert len(handler.bot_profiles) == 5
+            # First 2 IPs should have been evicted (LRU)
+            assert '10.0.0.0' not in handler.bot_profiles
+            assert '10.0.0.1' not in handler.bot_profiles
+            assert '10.0.0.2' in handler.bot_profiles
+            assert '10.0.0.6' in handler.bot_profiles
+
+        finally:
+            handler.MAX_PROFILES = original_max
+
+    def test_lru_access_moves_to_end(self, handler):
+        """Accessing a profile should move it to the end (most recently used)."""
+        # Lower cap for testing
+        original_max = handler.MAX_PROFILES
+        handler.MAX_PROFILES = 3
+
+        try:
+            # Create profiles in order
+            handler.get_or_create_profile('1.1.1.1')
+            handler.get_or_create_profile('2.2.2.2')
+            handler.get_or_create_profile('3.3.3.3')
+
+            # Access first profile — should move it to end
+            handler.get_profile('1.1.1.1')
+
+            # Now add a new one — oldest (2.2.2.2) should be evicted
+            handler.get_or_create_profile('4.4.4.4')
+
+            assert len(handler.bot_profiles) == 3
+            assert '2.2.2.2' not in handler.bot_profiles  # Evicted
+            assert '1.1.1.1' in handler.bot_profiles  # Still there (was accessed)
+
+        finally:
+            handler.MAX_PROFILES = original_max
+
+    def test_memory_stays_bounded_with_many_ips(self, handler):
+        """Memory should stay bounded even when many distinct IPs connect."""
+        original_max = handler.MAX_PROFILES
+        handler.MAX_PROFILES = 100
+
+        try:
+            # Simulate 1000 unique IPs
+            for i in range(1000):
+                profile = handler.get_or_create_profile(f'192.168.{i // 256}.{i % 256}')
+                profile.record_request({'path': f'/scan{i}', 'method': 'GET'})
+
+            # Cache should never exceed MAX_PROFILES
+            assert len(handler.bot_profiles) <= handler.MAX_PROFILES
+
+        finally:
+            handler.MAX_PROFILES = original_max


### PR DESCRIPTION
## Summary

Fix unbounded memory growth from #97 — every unique IP now accumulates a bounded BotProfile.

### Per-profile caps (bot_profile.py)
- `request_history` capped at MAX_HISTORY=500 entries (oldest evicted on append)
- `dialogue` capped at MAX_DIALOGUE=500 entries (oldest evicted on append)

### Handler-level LRU cache (base_handler.py)
- `bot_profiles` is now an OrderedDict with MAX_PROFILES=1000 limit
- `get_or_create_profile()` moves accessed profiles to end (LRU tracking)
- When at capacity, least-recently-used profile is evicted
- `get_profile()` also follows LRU pattern

### Tests added
- `test_request_history_eviction` — verifies per-profile cap enforcement
- `test_dialogue_eviction` — verifies dialogue cap enforcement  
- `test_lru_eviction_on_capacity` — verifies handler-level eviction
- `test_lru_access_moves_to_end` — verifies LRU tracking on access
- `test_memory_stays_bounded_with_many_ips` — stress test with 1000 IPs