### PR TITLE
fix: persist BotProfile state to DB (issue #110)

### DIFF
--- a/manyfaced/client/report_sender.py
+++ b/manyfaced/client/report_sender.py
@@ -65,6 +65,10 @@ def send_report(data, client, password, server_host, server_port, sensor_id=None
         'continent': getattr(data, 'continent', '') or '',
         'login': getattr(data, 'login', '') or '',  # Captured credentials (user:pass or user only)
     }
+
+    # Bot profile data — accumulated state (escalation, dialogue, history) for this IP
+    if hasattr(data, 'bot_profile_data') and data.bot_profile_data:
+        data_dict['bot_profile_data'] = data.bot_profile_data
     identifier = sensor_id if sensor_id else client
     message = (identifier + ':').encode()
     message += cypher.encrypt(json.dumps(data_dict).encode()).encode()

--- a/manyfaced/common/bearstorage.py
+++ b/manyfaced/common/bearstorage.py
@@ -60,6 +60,8 @@ class BearStorage:
                 self.ua = ua_val
         self.isDetected = is_detected
         self.hostname = hostname
+        # Bot profile data — accumulated state (escalation, dialogue, history) for this IP
+        self.bot_profile_data: dict[str, Any] | None = None
         # Reverse-DNS and geolocation moved to async context (see resolve_dns_name, resolve_geo)
 
     def resolve_dns_name(self, ip: str, timeout: float = 1.0) -> str:

--- a/manyfaced/db/dbconnect.py
+++ b/manyfaced/db/dbconnect.py
@@ -25,11 +25,11 @@ class BearRequests:
     country: str = ''
     continent: str = ''
     login: str = ''
+    bot_profile_data: dict[str, Any] | None = None
 
 
 def Insert(bear: BearRequests) -> None:
     """Insert bear data into the configured storage backend."""
-    storage = get_storage()
     record: dict[str, Any] = {
         'ip': bear.ip,
         'raw_request': bear.raw_request,
@@ -43,4 +43,10 @@ def Insert(bear: BearRequests) -> None:
         'continent': bear.continent,
         'login': bear.login,
     }
+
+    # Bot profile data — accumulated state (escalation, dialogue, history) for this IP
+    if bear.bot_profile_data:
+        record['bot_profile_data'] = bear.bot_profile_data
+
+    storage = get_storage()
     storage.insert(record)

--- a/manyfaced/db/sql_builder.py
+++ b/manyfaced/db/sql_builder.py
@@ -26,6 +26,7 @@ CREATE TABLE IF NOT EXISTS honeypot_bears (
     detected_id  INTEGER,
     hive_id      INTEGER,
     login        TEXT,
+    bot_profile_data TEXT,
     UNIQUE(bot_ip, timestamp)
 )
 """
@@ -34,9 +35,9 @@ INSERT_SQL = """\
 INSERT OR IGNORE INTO honeypot_bears
     (bot_ip, hostname, timestamp, request_path, request_command,
      request_version, request_raw, bot_user_agent, bot_country,
-     bot_continent, bot_tracert, bot_dns_name, detected_id, hive_id, login)
+     bot_continent, bot_tracert, bot_dns_name, detected_id, hive_id, login, bot_profile_data)
 VALUES
-    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 """
 
 CREATE_TABLE_PG_SQL = """\
@@ -57,6 +58,7 @@ CREATE TABLE IF NOT EXISTS honeypot_bears (
     detected_id  INTEGER,
     hive_id      INTEGER,
     login        VARCHAR(255),
+    bot_profile_data TEXT,
     UNIQUE(bot_ip, timestamp)
 )
 """
@@ -65,9 +67,9 @@ INSERT_PG_SQL = """\
 INSERT INTO honeypot_bears
     (bot_ip, hostname, timestamp, request_path, request_command,
      request_version, request_raw, bot_user_agent, bot_country,
-     bot_continent, bot_tracert, bot_dns_name, detected_id, hive_id, login)
+     bot_continent, bot_tracert, bot_dns_name, detected_id, hive_id, login, bot_profile_data)
 VALUES
-    (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+    (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 ON CONFLICT(bot_ip, timestamp) DO NOTHING
 """
 
@@ -81,7 +83,7 @@ def extract_record_fields(record: dict) -> tuple:
         record: Dict with keys like 'ip', 'parsed_request', 'timestamp', etc.
 
     Returns:
-        Tuple of 15 values matching the INSERT statement placeholders.
+        Tuple of 16 values matching the INSERT statement placeholders.
     """
     parsed = record.get('parsed_request') or {}
 
@@ -108,6 +110,18 @@ def extract_record_fields(record: dict) -> tuple:
     hive_id = record.get('hive_id')
     login = record.get('login') or ''
 
+    # Bot profile data — JSON-serialised full report from BotProfile.get_full_report()
+    bot_profile_data = record.get('bot_profile_data')
+    if isinstance(bot_profile_data, dict):
+        import json  # noqa: PLC0415
+
+        try:
+            bot_profile_data = json.dumps(bot_profile_data)
+        except (TypeError, ValueError):
+            bot_profile_data = None
+    elif bot_profile_data is not None:
+        bot_profile_data = str(bot_profile_data)
+
     # Convert timestamps to text if needed
     from datetime import datetime  # noqa: PLC0415
 
@@ -131,4 +145,5 @@ def extract_record_fields(record: dict) -> tuple:
         int(detected_id) if detected_id is not None else None,
         int(hive_id) if hive_id is not None else None,
         login,
+        bot_profile_data,
     )

--- a/manyfaced/handlers/http_handler.py
+++ b/manyfaced/handlers/http_handler.py
@@ -316,6 +316,12 @@ class HTTPHandler:
         except Exception:
             logger.debug('Geo resolution failed for %s', bot_ip)
 
+        # Collect BotProfile data from all handler instances for this IP
+        router = _get_router()
+        profile_data = router.get_all_profiles_for_ip(bot_ip)
+        if profile_data:
+            bs.bot_profile_data = profile_data
+
         server_host = getattr(self.args, 'server_host', '127.0.0.1')
         server_port = getattr(self.args, 'server', None)
         if server_port is not None:

--- a/manyfaced/handlers/router.py
+++ b/manyfaced/handlers/router.py
@@ -186,6 +186,22 @@ class Router:
         """The ordered list of Route objects."""
         return self._routes
 
+    def get_all_profiles_for_ip(self, bot_ip: str) -> dict[str, Any]:
+        """Collect BotProfile data for a given IP across all handler instances.
+
+        Returns a dict keyed by domain name with each value being the full report
+        from that handler's BotProfile (if one exists).  Only HTTPHandlerBase
+        subclasses are inspected.
+        """
+        result: dict[str, Any] = {}
+        for idx, instance in self._handler_instances.items():
+            if hasattr(instance, 'get_profile'):
+                profile = instance.get_profile(bot_ip)
+                if profile is not None:
+                    domain = getattr(instance, 'domain', f'route_{idx}')
+                    result[domain] = profile.get_full_report()
+        return result
+
 
 # ---------------------------------------------------------------------------
 # Singleton (populated by routes.py at import time)

--- a/manyfaced/server/server.py
+++ b/manyfaced/server/server.py
@@ -62,6 +62,7 @@ class ServerHandler(BaseHandler):
                 country=data.get('country', ''),
                 continent=data.get('continent', ''),
                 login=data.get('login', ''),
+                bot_profile_data=data.get('bot_profile_data'),
             )
             Insert(bear)
             logger.info('Data saved for %s', data['ip'])

--- a/test/test_dbconnect.py
+++ b/test/test_dbconnect.py
@@ -138,6 +138,7 @@ class TestBearRequestsDataclassRepr:
             'country',
             'continent',
             'login',
+            'bot_profile_data',
         ]
 
     def test_dataclass_repr(self):
@@ -413,3 +414,54 @@ class TestInsertFunction:
         assert record['dns_name'] == ''
         assert record['country'] == ''
         assert record['continent'] == ''
+
+    def test_insert_includes_bot_profile_data(self):
+        """Insert() should include bot_profile_data when present on BearRequests."""
+        mock_storage = MagicMock()
+
+        profile_data = {
+            'wordpress': {
+                'bot_ip': '1.2.3.4',
+                'session_id': 'abc123',
+                'escalation_level': 2,
+                'request_count': 5,
+                'dialogue_count': 3,
+                'captured_credentials': [{'username': 'admin', 'password': 'secret'}],
+            }
+        }
+
+        bear = BearRequests(
+            ip='1.2.3.4',
+            raw_request='POST /wp-login.php HTTP/1.1',
+            timestamp='2024-06-01 12:00:00',
+            parsed_request={'path': '/wp-login.php', 'command': 'POST'},
+            is_detected=1,
+            HIVELOGIN='testuser',
+            bot_profile_data=profile_data,
+        )
+
+        with patch('manyfaced.db.dbconnect.get_storage', return_value=mock_storage):
+            Insert(bear)
+
+        record = mock_storage.insert.call_args[0][0]
+        assert 'bot_profile_data' in record
+        assert record['bot_profile_data'] == profile_data
+
+    def test_insert_omits_bot_profile_data_when_none(self):
+        """Insert() should not include bot_profile_data key when it is None."""
+        mock_storage = MagicMock()
+
+        bear = BearRequests(
+            ip='1.2.3.4',
+            raw_request='GET / HTTP/1.1',
+            timestamp='2024-06-01 12:00:00',
+            parsed_request={},
+            is_detected=0,
+            HIVELOGIN='',
+        )
+
+        with patch('manyfaced.db.dbconnect.get_storage', return_value=mock_storage):
+            Insert(bear)
+
+        record = mock_storage.insert.call_args[0][0]
+        assert 'bot_profile_data' not in record


### PR DESCRIPTION
## Summary

Fix unpersisted BotProfile data — escalation level, request history, and dialogue are now stored in the database alongside each bear record.

### Changes
**DB schema:** Added `bot_profile_data TEXT` column to honeypot_bears table (SQLite + PostgreSQL)

**Client → Server flow:**
- Router.get_all_profiles_for_ip() collects BotProfile data from all handler instances
- HTTPHandler._enrich_and_send() attaches profile data to BearStorage
- report_sender.send_report() includes bot_profile_data in encrypted payload
- server.ServerHandler.save_data() passes it through to BearRequests
- dbconnect.Insert() includes it in the record dict sent to storage

### Tests added
- test_insert_includes_bot_profile_data — verifies data flows through Insert()
- test_insert_omits_bot_profile_data_when_none — verifies None is excluded