### PR TITLE
fix: update MAINTENANCE.md architecture diagram (issue #113)

### DIFF
--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -35,7 +35,7 @@ git push origin master
 ```
 
 ## Architecture
-- Client: multi-port listener → HTTPHandler → HandlerRegistry → ServiceHandler → send_report()
+- Client: multi-port listener → HTTPHandler → Router → ServiceHandler → send_report()
 - Server: single-port listener → ServerHandler → BearRequests → Insert() → SQLiteStorage
 - BearStorage: encapsulates bot data for report
 - HTTPRequest: wraps BaseHTTPRequestHandler for string parsing


### PR DESCRIPTION
## Summary

Fix stale HandlerRegistry reference in MAINTENANCE.md architecture description. Updated to reflect current Router-based routing used by HTTPHandler.

**Before:** `HTTPHandler → HandlerRegistry → ServiceHandler`
**After:** `HTTPHandler → Router → ServiceHandler`