### PR TITLE
feat: add alerting/notification hooks for credential captures (issue #125)

### DIFF
--- a/manyfaced/common/alerting.py
+++ b/manyfaced/common/alerting.py
@@ -1,0 +1,372 @@
+"""Alerting/notification system for credential captures and other events.
+
+Supports multiple notification channels:
+- Telegram bot messages (via Bot API)
+- Email (SMTP)
+- Webhook (HTTP POST to arbitrary URL)
+
+Configuration is loaded from config.toml [alerting] section or environment variables
+with HONEY_ALERT_ prefix.
+
+Usage:
+    from manyfaced.common.alerting import notify_credential_capture, send_alert
+
+    # Send credential capture alert
+    notify_credential_capture(ip='1.2.3.4', credentials='admin:password123', path='/login')
+
+    # Generic alert (for future use)
+    send_alert('System warning', 'Disk space low on /dev/sda1')
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import smtplib
+from dataclasses import dataclass
+from email.mime.text import MIMEText
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AlertConfig:
+    """Alerting configuration loaded from config.toml or environment variables."""
+
+    # Telegram settings
+    TELEGRAM_BOT_TOKEN: str = ''
+    TELEGRAM_CHAT_ID: str = ''
+
+    # Email settings
+    SMTP_HOST: str = 'localhost'
+    SMTP_PORT: int = 587
+    SMTP_USER: str = ''
+    SMTP_PASSWORD: str = ''
+    FROM_EMAIL: str = ''
+    TO_EMAILS: tuple[str, ...] = ()
+
+    # Webhook settings
+    WEBHOOK_URL: str = ''
+
+    # General
+    ENABLED: bool = False
+    LOG_ONLY: bool = True  # If True, only log alerts (no external notifications)
+
+
+def _load_alert_config() -> AlertConfig:
+    """Load alerting configuration from config.toml or environment variables."""
+    try:
+        from manyfaced.common.config import settings  # noqa: PLC0415
+
+        toml_path = getattr(settings, 'ALERT_CONFIG', None)
+        if toml_path:
+            import tomllib  # noqa: PLC0415
+
+            with open(toml_path, 'rb') as f:
+                raw = tomllib.load(f)
+            alerting = raw.get('alerting', {})
+        else:
+            alerting = {}
+    except Exception:
+        alerting = {}
+
+    prefix = 'HONEY_ALERT_'
+
+    def env(key: str, default: Any = '') -> str:
+        return (
+            settings.__dict__.get(f'{prefix}{key}', default)
+            if hasattr(settings, f'{prefix}{key}')
+            else ''
+        )
+
+    # Load from TOML first, then override with environment variables
+    telegram_token = alerting.get('telegram_bot_token', env('TELEGRAM_BOT_TOKEN', '')) or ''
+    telegram_chat_id = alerting.get('telegram_chat_id', env('TELEGRAM_CHAT_ID', '')) or ''
+    smtp_host = alerting.get('smtp_host', env('SMTP_HOST', 'localhost')) or 'localhost'
+    smtp_port_str = alerting.get('smtp_port', env('SMTP_PORT', '587')) or '587'
+    try:
+        smtp_port = int(smtp_port_str)
+    except (ValueError, TypeError):
+        smtp_port = 587
+    smtp_user = alerting.get('smtp_user', env('SMTP_USER', '')) or ''
+    smtp_password = alerting.get('smtp_password', env('SMTP_PASSWORD', '')) or ''
+    from_email = alerting.get('from_email', env('FROM_EMAIL', '')) or ''
+    to_emails_str = alerting.get('to_emails', env('TO_EMAILS', '')) or ''
+    webhook_url = alerting.get('webhook_url', env('WEBHOOK_URL', '')) or ''
+
+    enabled_str = alerting.get('enabled', env('ENABLED', 'false')) or 'false'
+    log_only_str = alerting.get('log_only', env('LOG_ONLY', 'true')) or 'true'
+    enabled = str(enabled_str).lower() in ('true', '1', 'yes')
+    log_only = str(log_only_str).lower() in ('true', '1', 'yes')
+
+    to_emails = (
+        tuple(e.strip() for e in to_emails_str.split(',') if e.strip()) if to_emails_str else ()
+    )
+
+    return AlertConfig(
+        TELEGRAM_BOT_TOKEN=telegram_token,
+        TELEGRAM_CHAT_ID=telegram_chat_id,
+        SMTP_HOST=smtp_host,
+        SMTP_PORT=smtp_port,
+        SMTP_USER=smtp_user,
+        SMTP_PASSWORD=smtp_password,
+        FROM_EMAIL=from_email,
+        TO_EMAILS=to_emails,
+        WEBHOOK_URL=webhook_url,
+        ENABLED=enabled or not log_only,
+        LOG_ONLY=log_only,
+    )
+
+
+# Global alert config instance (loaded once at module import)
+alert_config: AlertConfig = _load_alert_config()
+
+
+def send_telegram_message(token: str, chat_id: str, message: str) -> bool:
+    """Send a message to Telegram via Bot API.
+
+    Args:
+        token: Telegram bot token.
+        chat_id: Target chat/channel ID.
+        message: Message text to send.
+
+    Returns:
+        True if message was sent successfully, False otherwise.
+    """
+    try:
+        import urllib.request  # noqa: PLC0415
+
+        url = f'https://api.telegram.org/bot{token}/sendMessage'
+        payload = json.dumps(
+            {
+                'chat_id': chat_id,
+                'text': message,
+                'parse_mode': 'HTML',
+            }
+        ).encode()
+
+        req = urllib.request.Request(
+            url,
+            data=payload,
+            headers={'Content-Type': 'application/json'},
+            method='POST',
+        )
+
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            result = json.loads(resp.read().decode())
+            return result.get('ok', False)
+
+    except Exception as e:
+        logger.error('Failed to send Telegram message: %s', e)
+        return False
+
+
+def send_email_alert(
+    smtp_host: str,
+    smtp_port: int,
+    smtp_user: str,
+    smtp_password: str,
+    from_email: str,
+    to_emails: tuple[str, ...],
+    subject: str,
+    body: str,
+) -> bool:
+    """Send an email alert via SMTP.
+
+    Args:
+        smtp_host: SMTP server hostname.
+        smtp_port: SMTP server port.
+        smtp_user: SMTP username.
+        smtp_password: SMTP password.
+        from_email: Sender email address.
+        to_emails: Tuple of recipient email addresses.
+        subject: Email subject line.
+        body: Email body text.
+
+    Returns:
+        True if email was sent successfully, False otherwise.
+    """
+    try:
+        msg = MIMEText(body)
+        msg['Subject'] = subject
+        msg['From'] = from_email
+        msg['To'] = ', '.join(to_emails)
+
+        with smtplib.SMTP(smtp_host, smtp_port, timeout=10) as server:
+            server.starttls()
+            if smtp_user and smtp_password:
+                server.login(smtp_user, smtp_password)
+            server.sendmail(from_email, to_emails, msg.as_string())
+
+        return True
+
+    except Exception as e:
+        logger.error('Failed to send email alert: %s', e)
+        return False
+
+
+def send_webhook_alert(url: str, payload: dict[str, Any]) -> bool:
+    """Send an alert via HTTP POST webhook.
+
+    Args:
+        url: Webhook URL to POST to.
+        payload: Dictionary of data to send as JSON.
+
+    Returns:
+        True if request was successful (2xx status), False otherwise.
+    """
+    try:
+        import urllib.request  # noqa: PLC0415
+
+        data = json.dumps(payload).encode()
+        req = urllib.request.Request(
+            url,
+            data=data,
+            headers={'Content-Type': 'application/json'},
+            method='POST',
+        )
+
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return 200 <= resp.status < 300
+
+    except Exception as e:
+        logger.error('Failed to send webhook alert: %s', e)
+        return False
+
+
+def notify_credential_capture(
+    ip: str,
+    credentials: str,
+    path: str = '/',
+    hostname: str = '',
+) -> None:
+    """Send notification when credentials are captured from a honeypot connection.
+
+    This is the primary entry point for credential capture alerts. It logs at ERROR level
+    and optionally sends notifications via configured channels (Telegram, email, webhook).
+
+    Args:
+        ip: IP address of the bot that submitted credentials.
+        credentials: Captured credentials string (e.g., 'admin:password123').
+        path: Request path where credentials were captured.
+        hostname: Honeypot hostname/identifier that received the credentials.
+    """
+    # Always log at ERROR level for visibility in logs
+    alert_message = (
+        f'⚠️ CREDENTIAL CAPTURE DETECTED\n'
+        f'IP: {ip}\n'
+        f'Credentials: {credentials}\n'
+        f'Path: {path}\n'
+        f'Honeypot: {hostname or "unknown"}\n'
+        f'Timestamp: {__import__("datetime").datetime.now().isoformat()}'
+    )
+
+    logger.error(alert_message)
+
+    # If only logging, don't send external notifications
+    if alert_config.LOG_ONLY:
+        return
+
+    # Send Telegram notification if configured
+    if alert_config.TELEGRAM_BOT_TOKEN and alert_config.TELEGRAM_CHAT_ID:
+        telegram_msg = (
+            f'<b>⚠️ CREDENTIAL CAPTURE</b>\n'
+            f'<b>IP:</b> <code>{ip}</code>\n'
+            f'<b>Credentials:</b> <code>{credentials}</code>\n'
+            f'<b>Path:</b> {path}\n'
+            f'<b>Honeypot:</b> {hostname or "unknown"}\n'
+            f'<b>Time:</b> {__import__("datetime").datetime.now().strftime("%Y-%m-%d %H:%M:%S")}'
+        )
+        send_telegram_message(
+            alert_config.TELEGRAM_BOT_TOKEN,
+            alert_config.TELEGRAM_CHAT_ID,
+            telegram_msg,
+        )
+
+    # Send email notification if configured
+    if alert_config.FROM_EMAIL and alert_config.TO_EMAILS:
+        subject = f'[Honeypot Alert] Credential capture from {ip}'
+        body = (
+            f'CREDENTIAL CAPTURE DETECTED\n'
+            f'=========================\n\n'
+            f'IP Address: {ip}\n'
+            f'Credentials: {credentials}\n'
+            f'Request Path: {path}\n'
+            f'Honeypot Hostname: {hostname or "unknown"}\n'
+            f'Timestamp: {__import__("datetime").datetime.now().isoformat()}'
+        )
+        send_email_alert(
+            alert_config.SMTP_HOST,
+            alert_config.SMTP_PORT,
+            alert_config.SMTP_USER,
+            alert_config.SMTP_PASSWORD,
+            alert_config.FROM_EMAIL,
+            alert_config.TO_EMAILS,
+            subject,
+            body,
+        )
+
+    # Send webhook notification if configured
+    if alert_config.WEBHOOK_URL:
+        payload = {
+            'event': 'credential_capture',
+            'ip': ip,
+            'credentials': credentials,
+            'path': path,
+            'hostname': hostname or '',
+            'timestamp': __import__('datetime').datetime.now().isoformat(),
+        }
+        send_webhook_alert(alert_config.WEBHOOK_URL, payload)
+
+
+def send_alert(title: str, message: str) -> None:
+    """Send a generic alert via configured channels.
+
+    This is a general-purpose alert function for future use (e.g., system warnings,
+    database errors, etc.). Currently only logs at ERROR level unless external
+    notification channels are configured.
+
+    Args:
+        title: Alert title/summary.
+        message: Detailed alert message.
+    """
+    alert_text = f'⚠️ {title}\n{message}'
+    logger.error(alert_text)
+
+    if alert_config.LOG_ONLY:
+        return
+
+    # Send via all configured channels
+    if alert_config.TELEGRAM_BOT_TOKEN and alert_config.TELEGRAM_CHAT_ID:
+        send_telegram_message(
+            alert_config.TELEGRAM_BOT_TOKEN,
+            alert_config.TELEGRAM_CHAT_ID,
+            f'<b>{title}</b>\n{message}',
+        )
+
+    if alert_config.FROM_EMAIL and alert_config.TO_EMAILS:
+        send_email_alert(
+            alert_config.SMTP_HOST,
+            alert_config.SMTP_PORT,
+            alert_config.SMTP_USER,
+            alert_config.SMTP_PASSWORD,
+            alert_config.FROM_EMAIL,
+            alert_config.TO_EMAILS,
+            f'[Honeypot] {title}',
+            message,
+        )
+
+    if alert_config.WEBHOOK_URL:
+        send_webhook_alert(
+            alert_config.WEBHOOK_URL,
+            {'event': 'alert', 'title': title, 'message': message},
+        )
+
+
+__all__ = [
+    'AlertConfig',
+    'alert_config',
+    'notify_credential_capture',
+    'send_alert',
+]

--- a/manyfaced/handlers/http_handler.py
+++ b/manyfaced/handlers/http_handler.py
@@ -19,6 +19,7 @@ from manyfaced.common.credential_extractor import extract_http_credentials, form
 from manyfaced.common.httphandler import HTTPRequest
 from manyfaced.common.logging_setup import get_logger
 from manyfaced.common.protocol import detect_protocol, get_protocol_info
+from manyfaced.common.alerting import notify_credential_capture
 from manyfaced.common.status import (
     EMPTY_CONNECTION,
     SSH_CLIENT,
@@ -267,6 +268,12 @@ class HTTPHandler:
         if login_creds:
             bs.login = login_creds
             logger.info('Captured HTTP credentials from %s at %s', bot_ip, path)
+            notify_credential_capture(
+                ip=bot_ip,
+                credentials=login_creds,
+                path=path,
+                hostname=settings.HIVELOGIN,
+            )
 
         self._enrich_and_send(bs, bot_ip)
         return output_data

--- a/test/test_alerting.py
+++ b/test/test_alerting.py
@@ -1,0 +1,169 @@
+"""Tests for manyfaced.common.alerting — credential capture notifications."""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+
+class TestNotifyCredentialCapture:
+    """Test credential capture notification functionality."""
+
+    def test_notify_credential_capture_logs_error(self, caplog):
+        """Verify that notify_credential_capture logs at ERROR level."""
+        from manyfaced.common.alerting import notify_credential_capture
+
+        with caplog.at_level(logging.ERROR):
+            notify_credential_capture(
+                ip='1.2.3.4',
+                credentials='admin:password123',
+                path='/login',
+                hostname='test-honeypot',
+            )
+
+        assert 'CREDENTIAL CAPTURE DETECTED' in caplog.text
+        assert '1.2.3.4' in caplog.text
+        assert 'admin:password123' in caplog.text
+
+    def test_send_alert_logs_error(self, caplog):
+        """Verify that send_alert logs at ERROR level."""
+        from manyfaced.common.alerting import send_alert
+
+        with caplog.at_level(logging.ERROR):
+            send_alert('Test Alert', 'This is a test message')
+
+        assert 'Test Alert' in caplog.text
+        assert 'This is a test message' in caplog.text
+
+
+class TestAlertConfig:
+    """Test alert configuration loading."""
+
+    def test_default_config_values(self):
+        """Verify default configuration values are sensible."""
+        from manyfaced.common.alerting import AlertConfig, _load_alert_config
+
+        config = _load_alert_config()
+
+        # Default values should be safe (no external notifications by default)
+        assert config.LOG_ONLY is True
+        assert config.ENABLED is False
+        assert config.TELEGRAM_BOT_TOKEN == ''
+        assert config.SMTP_HOST == 'localhost'
+        assert config.SMTP_PORT == 587
+
+    def test_config_handles_missing_values(self):
+        """Verify configuration handles missing/empty values gracefully."""
+        from manyfaced.common.alerting import AlertConfig, _load_alert_config
+
+        # This should not raise any exceptions even with no config
+        config = _load_alert_config()
+
+        assert isinstance(config, AlertConfig)
+        assert hasattr(config, 'TELEGRAM_BOT_TOKEN')
+        assert hasattr(config, 'SMTP_HOST')
+        assert hasattr(config, 'WEBHOOK_URL')
+
+
+class TestSendFunctions:
+    """Test individual notification send functions."""
+
+    def test_send_telegram_message_failure(self):
+        """Verify send_telegram_message returns False on failure."""
+        from manyfaced.common.alerting import send_telegram_message
+
+        result = send_telegram_message('invalid_token', '123456', 'Test message')
+        assert result is False
+
+    def test_send_email_alert_failure(self):
+        """Verify send_email_alert returns False on failure."""
+        from manyfaced.common.alerting import send_email_alert
+
+        result = send_email_alert(
+            smtp_host='invalid.host',
+            smtp_port=587,
+            smtp_user='',
+            smtp_password='',
+            from_email='',
+            to_emails=(),
+            subject='Test',
+            body='Test message',
+        )
+        assert result is False
+
+    def test_send_webhook_alert_failure(self):
+        """Verify send_webhook_alert returns False on failure."""
+        from manyfaced.common.alerting import send_webhook_alert
+
+        result = send_webhook_alert('http://invalid.host/webhook', {'test': 'data'})
+        assert result is False
+
+
+class TestAlertConfigDataclass:
+    """Test AlertConfig dataclass structure."""
+
+    def test_dataclass_fields(self):
+        """Verify AlertConfig has all expected fields."""
+        from manyfaced.common.alerting import AlertConfig
+
+        config = AlertConfig()
+
+        # Check all required fields exist
+        assert hasattr(config, 'TELEGRAM_BOT_TOKEN')
+        assert hasattr(config, 'TELEGRAM_CHAT_ID')
+        assert hasattr(config, 'SMTP_HOST')
+        assert hasattr(config, 'SMTP_PORT')
+        assert hasattr(config, 'SMTP_USER')
+        assert hasattr(config, 'SMTP_PASSWORD')
+        assert hasattr(config, 'FROM_EMAIL')
+        assert hasattr(config, 'TO_EMAILS')
+        assert hasattr(config, 'WEBHOOK_URL')
+        assert hasattr(config, 'ENABLED')
+        assert hasattr(config, 'LOG_ONLY')
+
+    def test_dataclass_defaults(self):
+        """Verify AlertConfig default values."""
+        from manyfaced.common.alerting import AlertConfig
+
+        config = AlertConfig()
+
+        # String fields should be empty by default
+        assert config.TELEGRAM_BOT_TOKEN == ''
+        assert config.SMTP_HOST == 'localhost'
+        assert config.FROM_EMAIL == ''
+        assert config.WEBHOOK_URL == ''
+
+        # Integer field should have sensible default
+        assert config.SMTP_PORT == 587
+
+        # Tuple field should be empty by default
+        assert config.TO_EMAILS == ()
+
+        # Boolean fields should default to safe values
+        assert config.ENABLED is False
+        assert config.LOG_ONLY is True
+
+
+class TestIntegration:
+    """Integration tests for alerting system."""
+
+    def test_notify_credential_capture_integration(self):
+        """Test full integration of credential capture notification."""
+        from manyfaced.common.alerting import notify_credential_capture, alert_config
+
+        # This should not raise any exceptions even with default config
+        notify_credential_capture(
+            ip='192.168.1.100',
+            credentials='admin:secret123',
+            path='/login',
+            hostname='production-honeypot',
+        )
+
+        # Verify it completed without errors (logging is the only action with default config)
+
+
+__all__ = [
+    'TestNotifyCredentialCapture',
+    'TestAlertConfig',
+    'TestSendFunctions',
+    'TestAlertConfigDataclass',
+    'TestIntegration',
+]


### PR DESCRIPTION
## Summary

Fixes **issue #125**: Added comprehensive alerting system that notifies operators when credentials are captured from honeypot connections.

## Changes

### `manyfaced/common/alerting.py` (new file)
- **AlertConfig dataclass**: Configuration for all notification channels
- **notify_credential_capture()**: Primary entry point for credential capture alerts
- **send_alert()**: Generic alert function for future use
- **Telegram integration**: Send messages via Bot API with HTML formatting
- **Email integration**: Send alerts via SMTP with proper MIME formatting
- **Webhook integration**: POST JSON payloads to arbitrary URLs

### `manyfaced/handlers/http_handler.py`
- Added import for `notify_credential_capture`
- Calls alert function when credentials are captured from bot requests

## Configuration

Add `[alerting]` section to config.toml:

```toml
[alerting]
enabled = true  # Enable external notifications (default: false)
log_only = false  # If true, only log alerts (no external notifications)

# Telegram settings
telegram_bot_token = "YOUR_BOT_TOKEN"
telegram_chat_id = "YOUR_CHAT_ID"

# Email settings
smtp_host = "smtp.example.com"
smtp_port = 587
smtp_user = "your@email.com"
smtp_password = "your_password"
from_email = "honeypot@example.com"
to_emails = "admin1@example.com,admin2@example.com"

# Webhook settings
webhook_url = "https://hooks.example.com/alerts"
```

Or use environment variables with `HONEY_ALERT_` prefix:
- `HONEY_ALERT_TELEGRAM_BOT_TOKEN`
- `HONEY_ALERT_TELEGRAM_CHAT_ID`
- `HONEY_ALERT_SMTP_HOST`
- etc.

## Alert Format

### Telegram Message (HTML formatted)
```
⚠️ CREDENTIAL CAPTURE
IP: 192.168.1.100
Credentials: admin:password123
Path: /login
Honeypot: sensor-01
Time: 2024-01-15 14:30:00
```

### Email Subject
`[Honeypot Alert] Credential capture from 192.168.1.100`

### Webhook Payload (JSON)
```json
{
  "event": "credential_capture",
  "ip": "192.168.1.100",
  "credentials": "admin:password123",
  "path": "/login",
  "hostname": "sensor-01",
  "timestamp": "2024-01-15T14:30:00"
}
```

## Logging

All credential captures are logged at ERROR level regardless of configuration:
```
ERROR:manyfaced.common.alerting:⚠️ CREDENTIAL CAPTURE DETECTED
IP: 192.168.1.100
Credentials: admin:password123
Path: /login
Honeypot: sensor-01
Timestamp: 2024-01-15T14:30:00
```