### PR TITLE
Supervision restart loop backoff + crash-loop cap (issue #180)

### DIFF
--- a/manyfaced/mfh.py
+++ b/manyfaced/mfh.py
@@ -176,8 +176,7 @@ def run() -> None:
     # off between restarts and, if a child keeps dying, fail the whole service
     # so systemd escalates recovery (and its own alerting can fire).
     supervise: dict[str, dict] = {
-        key: {'attempts': 0, 'last': 0.0, 'times': []}
-        for key in ('client_proc', 'server_proc')
+        key: {'attempts': 0, 'last': 0.0, 'times': []} for key in ('client_proc', 'server_proc')
     }
 
     def _maybe_restart(key: str, spawn) -> None:
@@ -198,7 +197,9 @@ def run() -> None:
                 int(_RESTART_WINDOW_SEC),
             )
             sys.exit(1)
-        logger.warning('%s child exited unexpectedly -- restarting (attempt %d)', key, st['attempts'] + 1)
+        logger.warning(
+            '%s child exited unexpectedly -- restarting (attempt %d)', key, st['attempts'] + 1
+        )
         new_proc = spawn()
         new_proc.start()
         procs[key] = new_proc

--- a/manyfaced/mfh.py
+++ b/manyfaced/mfh.py
@@ -18,6 +18,13 @@ logger = logging.getLogger(__name__)
 
 _lock_fd = None
 
+# Supervision tuning for the child-restart loop (see run()). Hoisted to module
+# scope so they can be overridden in tests.
+_BACKOFF_BASE = 1.0
+_BACKOFF_MAX = 30.0
+_MAX_RESTARTS_PER_WINDOW = 10
+_RESTART_WINDOW_SEC = 60.0
+
 
 def _acquire_lockfile():
     """Acquire an exclusive lockfile to prevent multiple instances.
@@ -162,25 +169,62 @@ def run() -> None:
     # child dies (e.g. the server / DB-writer crashes) and is left unrestarted,
     # the client keeps capturing bots but can never deliver reports, so
     # recording goes silently silent while the service still reports "active".
+    # Supervision with exponential backoff + a crash-loop guard. A child that
+    # dies on startup would otherwise be restarted every ~1s forever, spawning a
+    # fresh process each second and bypassing systemd's Restart=on-failure (the
+    # parent stays alive, so systemd never sees a unit failure). Instead we back
+    # off between restarts and, if a child keeps dying, fail the whole service
+    # so systemd escalates recovery (and its own alerting can fire).
+    supervise: dict[str, dict] = {
+        key: {'attempts': 0, 'last': 0.0, 'times': []}
+        for key in ('client_proc', 'server_proc')
+    }
+
+    def _maybe_restart(key: str, spawn) -> None:
+        st = supervise[key]
+        now = time.time()
+        # Still cooling down after the previous restart — wait this round.
+        backoff = min(_BACKOFF_BASE * (2 ** st['attempts']), _BACKOFF_MAX)
+        if st['last'] and now - st['last'] < backoff:
+            return
+        # Crash-loop guard: too many restarts in the window => give up so
+        # systemd's Restart=on-failure (and its alerting) takes over.
+        st['times'] = [t for t in st['times'] if now - t < _RESTART_WINDOW_SEC]
+        if len(st['times']) >= _MAX_RESTARTS_PER_WINDOW:
+            logger.critical(
+                'Child %s restarted %d times in %ds — giving up so systemd can recover',
+                key,
+                len(st['times']),
+                int(_RESTART_WINDOW_SEC),
+            )
+            sys.exit(1)
+        logger.warning('%s child exited unexpectedly -- restarting (attempt %d)', key, st['attempts'] + 1)
+        new_proc = spawn()
+        new_proc.start()
+        procs[key] = new_proc
+        st['attempts'] += 1
+        st['last'] = now
+        st['times'].append(now)
+
     try:
         while not update_event.is_set():
             # Supervise children: restart any that have exited. A dead server
             # child means reports can't be persisted; a dead client child means
             # no bots are captured. Either way we must recover without a full
             # service restart (which Restart=on-failure would otherwise miss,
-            # since the parent process itself stays alive).
-            if args.client is not None and (
-                procs['client_proc'] is None or not procs['client_proc'].is_alive()
-            ):
-                logger.warning('client child exited unexpectedly -- restarting')
-                procs['client_proc'] = _spawn_client()
-                procs['client_proc'].start()
-            if args.server is not None and (
-                procs['server_proc'] is None or not procs['server_proc'].is_alive()
-            ):
-                logger.warning('server child exited unexpectedly -- restarting')
-                procs['server_proc'] = _spawn_server()
-                procs['server_proc'].start()
+            # since the parent process itself stays alive). A child that is
+            # healthy resets its restart bookkeeping so the crash-loop guard
+            # only counts sustained failures.
+            if args.client is not None:
+                if procs['client_proc'] is not None and procs['client_proc'].is_alive():
+                    supervise['client_proc'] = {'attempts': 0, 'last': 0.0, 'times': []}
+                elif procs['client_proc'] is None or not procs['client_proc'].is_alive():
+                    _maybe_restart('client_proc', _spawn_client)
+            if args.server is not None:
+                if procs['server_proc'] is not None and procs['server_proc'].is_alive():
+                    supervise['server_proc'] = {'attempts': 0, 'last': 0.0, 'times': []}
+                elif procs['server_proc'] is None or not procs['server_proc'].is_alive():
+                    _maybe_restart('server_proc', _spawn_server)
             time.sleep(1)
     except KeyboardInterrupt:
         pass

--- a/test/test_mfh.py
+++ b/test/test_mfh.py
@@ -318,7 +318,9 @@ class TestRunPortModeFromConfig(unittest.TestCase):
 class TestRunChildSupervision(unittest.TestCase):
     """Test the supervision loop: backoff + crash-loop guard (#180)."""
 
-    def _run_with_dead_child(self, kill_parent_after_n_restarts, window_constants, event_toggles_true_at=0):
+    def _run_with_dead_child(
+        self, kill_parent_after_n_restarts, window_constants, event_toggles_true_at=0
+    ):
         """Drive run() with a child that is never alive.
 
         Args:
@@ -333,18 +335,20 @@ class TestRunChildSupervision(unittest.TestCase):
         """
         import manyfaced.mfh as mfh
 
-        with patch('manyfaced.mfh._acquire_lockfile'), \
-             patch('manyfaced.mfh.setup_logging'), \
-             patch('manyfaced.mfh.os.path.isfile', return_value=True), \
-             patch('manyfaced.mfh.settings', _make_mock_settings()), \
-             patch('manyfaced.common.arguments.parse') as mock_parse, \
-             patch('manyfaced.mfh.Process') as mock_process_cls, \
-             patch('manyfaced.mfh.Event') as mock_event_cls, \
-             patch('manyfaced.mfh.time.sleep'), \
-             patch.object(mfh, '_BACKOFF_BASE', window_constants['base']), \
-             patch.object(mfh, '_BACKOFF_MAX', window_constants['max']), \
-             patch.object(mfh, '_MAX_RESTARTS_PER_WINDOW', window_constants['max_restarts']), \
-             patch.object(mfh, '_RESTART_WINDOW_SEC', window_constants['window']):
+        with (
+            patch('manyfaced.mfh._acquire_lockfile'),
+            patch('manyfaced.mfh.setup_logging'),
+            patch('manyfaced.mfh.os.path.isfile', return_value=True),
+            patch('manyfaced.mfh.settings', _make_mock_settings()),
+            patch('manyfaced.common.arguments.parse') as mock_parse,
+            patch('manyfaced.mfh.Process') as mock_process_cls,
+            patch('manyfaced.mfh.Event') as mock_event_cls,
+            patch('manyfaced.mfh.time.sleep'),
+            patch.object(mfh, '_BACKOFF_BASE', window_constants['base']),
+            patch.object(mfh, '_BACKOFF_MAX', window_constants['max']),
+            patch.object(mfh, '_MAX_RESTARTS_PER_WINDOW', window_constants['max_restarts']),
+            patch.object(mfh, '_RESTART_WINDOW_SEC', window_constants['window']),
+        ):
             mock_args = MagicMock()
             mock_args.client = 8080
             mock_args.server = 9090
@@ -394,15 +398,17 @@ class TestRunChildSupervision(unittest.TestCase):
         """A child that stays alive is never restarted (no crash-loop)."""
         import manyfaced.mfh as mfh
 
-        with patch('manyfaced.mfh._acquire_lockfile'), \
-             patch('manyfaced.mfh.setup_logging'), \
-             patch('manyfaced.mfh.os.path.isfile', return_value=True), \
-             patch('manyfaced.mfh.settings', _make_mock_settings()), \
-             patch('manyfaced.common.arguments.parse') as mock_parse, \
-             patch('manyfaced.mfh.Process') as mock_process_cls, \
-             patch('manyfaced.mfh.Event') as mock_event_cls, \
-             patch('manyfaced.mfh.time.sleep'), \
-             patch.object(mfh, 'sys') as mock_sys:
+        with (
+            patch('manyfaced.mfh._acquire_lockfile'),
+            patch('manyfaced.mfh.setup_logging'),
+            patch('manyfaced.mfh.os.path.isfile', return_value=True),
+            patch('manyfaced.mfh.settings', _make_mock_settings()),
+            patch('manyfaced.common.arguments.parse') as mock_parse,
+            patch('manyfaced.mfh.Process') as mock_process_cls,
+            patch('manyfaced.mfh.Event') as mock_event_cls,
+            patch('manyfaced.mfh.time.sleep'),
+            patch.object(mfh, 'sys') as mock_sys,
+        ):
             mock_args = MagicMock()
             mock_args.client = 8080
             mock_args.server = 9090

--- a/test/test_mfh.py
+++ b/test/test_mfh.py
@@ -315,5 +315,118 @@ class TestRunPortModeFromConfig(unittest.TestCase):
                             self.assertEqual(mock_args.top_ports, '80,443')
 
 
+class TestRunChildSupervision(unittest.TestCase):
+    """Test the supervision loop: backoff + crash-loop guard (#180)."""
+
+    def _run_with_dead_child(self, kill_parent_after_n_restarts, window_constants, event_toggles_true_at=0):
+        """Drive run() with a child that is never alive.
+
+        Args:
+            kill_parent_after_n_restarts: if >0, sys.exit is allowed to fire
+                after this many restarts (crash-loop guard). Set 0 to assert
+                sys.exit is never called.
+            window_constants: dict overriding the module-level backoff/cap
+                constants so the loop can be exercised quickly.
+            event_toggles_true_at: after this many loop iterations the
+                update_event flips to set(), ending the loop cleanly (used for
+                the negative case where the guard must NOT fire).
+        """
+        import manyfaced.mfh as mfh
+
+        with patch('manyfaced.mfh._acquire_lockfile'), \
+             patch('manyfaced.mfh.setup_logging'), \
+             patch('manyfaced.mfh.os.path.isfile', return_value=True), \
+             patch('manyfaced.mfh.settings', _make_mock_settings()), \
+             patch('manyfaced.common.arguments.parse') as mock_parse, \
+             patch('manyfaced.mfh.Process') as mock_process_cls, \
+             patch('manyfaced.mfh.Event') as mock_event_cls, \
+             patch('manyfaced.mfh.time.sleep'), \
+             patch.object(mfh, '_BACKOFF_BASE', window_constants['base']), \
+             patch.object(mfh, '_BACKOFF_MAX', window_constants['max']), \
+             patch.object(mfh, '_MAX_RESTARTS_PER_WINDOW', window_constants['max_restarts']), \
+             patch.object(mfh, '_RESTART_WINDOW_SEC', window_constants['window']):
+            mock_args = MagicMock()
+            mock_args.client = 8080
+            mock_args.server = 9090
+            mock_args.generate_config = False
+            mock_args.port_mode = 'single'
+            mock_args.top_ports = None
+            mock_parse.return_value = mock_args
+
+            # Child process is never alive -> must be (re)started.
+            dead_proc = MagicMock()
+            dead_proc.is_alive.return_value = False
+            mock_process_cls.return_value = dead_proc
+
+            event = MagicMock()
+            state = {'i': 0}
+
+            def _is_set():
+                state['i'] += 1
+                return event_toggles_true_at > 0 and state['i'] > event_toggles_true_at
+
+            event.is_set.side_effect = _is_set
+            mock_event_cls.return_value = event
+
+            from manyfaced.mfh import run
+
+            run()
+            return mock_process_cls.call_count
+
+    def test_crash_loop_guard_exits_parent_after_cap(self):
+        """A child that keeps dying must trip the cap and sys.exit(1)."""
+        import manyfaced.mfh as mfh
+
+        # Cap at 3 restarts in a 1000s window; backoff tiny so all restarts
+        # happen in the first loop iteration sequence.
+        constants = {'base': 0.0, 'max': 0.0, 'max_restarts': 3, 'window': 1000.0}
+        with patch.object(mfh, 'sys') as mock_sys:
+            mock_sys.exit.side_effect = SystemExit(1)
+            with self.assertRaises(SystemExit) as cm:
+                self._run_with_dead_child(
+                    kill_parent_after_n_restarts=3,
+                    window_constants=constants,
+                )
+            self.assertEqual(cm.exception.code, 1)
+            mock_sys.exit.assert_called_once_with(1)
+
+    def test_healthy_child_resets_restart_bookkeeping(self):
+        """A child that stays alive is never restarted (no crash-loop)."""
+        import manyfaced.mfh as mfh
+
+        with patch('manyfaced.mfh._acquire_lockfile'), \
+             patch('manyfaced.mfh.setup_logging'), \
+             patch('manyfaced.mfh.os.path.isfile', return_value=True), \
+             patch('manyfaced.mfh.settings', _make_mock_settings()), \
+             patch('manyfaced.common.arguments.parse') as mock_parse, \
+             patch('manyfaced.mfh.Process') as mock_process_cls, \
+             patch('manyfaced.mfh.Event') as mock_event_cls, \
+             patch('manyfaced.mfh.time.sleep'), \
+             patch.object(mfh, 'sys') as mock_sys:
+            mock_args = MagicMock()
+            mock_args.client = 8080
+            mock_args.server = 9090
+            mock_args.generate_config = False
+            mock_args.port_mode = 'single'
+            mock_args.top_ports = None
+            mock_parse.return_value = mock_args
+
+            # Child is alive -> supervision must NOT restart it.
+            alive_proc = MagicMock()
+            alive_proc.is_alive.return_value = True
+            mock_process_cls.return_value = alive_proc
+
+            event = MagicMock()
+            event.is_set.return_value = True  # end loop immediately
+            mock_event_cls.return_value = event
+
+            from manyfaced.mfh import run
+
+            run()
+            # Both started once at launch, never restarted.
+            self.assertEqual(mock_process_cls.call_count, 2)
+            mock_sys.exit.assert_not_called()
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes #180. The child-supervision loop in `manyfaced/mfh.py` restarted any
dead child instantly on every 1s tick. A child that crashes on startup would
therefore be restarted ~once per second **forever**, spawning a fresh process
each time and bypassing systemd's `Restart=on-failure` (the parent stays
alive, so systemd never sees a unit failure — exactly the silent-degradation
class this supervision was meant to prevent).

## What changed
- **Exponential backoff** between restarts: `min(1s * 2**attempts, 30s)` cap.
- **Crash-loop guard**: if a child restarts ≥10 times within 60s, the parent
  calls `sys.exit(1)` so systemd escalates recovery (and its own alerting
  fires) instead of spinning forever.
- **Healthy-child reset**: a child that stays alive resets its restart
  bookkeeping, so the guard only counts *sustained* failures (a one-off crash
  followed by recovery is not punished).
- Tunables hoisted to module scope (`_BACKOFF_BASE`, `_BACKOFF_MAX`,
  `_MAX_RESTARTS_PER_WINDOW`, `_RESTART_WINDOW_SEC`) so they're testable.

## Verification
- `TestRunChildSupervision`: the cap trips `sys.exit(1)` after N restarts; a
  healthy child is never restarted.
- `ruff` clean, `basedpyright` clean (0 errors/warnings).

## Risk
- Only changes restart *pacing* and the failure-escalation path. Normal
  recovery (child dies, restarts, stays up) is unchanged and now even safer.