### PR TITLE
Dump record to JSONL fallback on exhausted lock contention (issue #183)

### DIFF
--- a/manyfaced/db/storage.py
+++ b/manyfaced/db/storage.py
@@ -209,6 +209,15 @@ class SQLiteStorage(StorageBackend):
                 'Giving up insert after lock contention (database is locked): %s',
                 last_exc,
             )
+            # Don't silently lose the record: fall back to the JSONL dump file
+            # (the same safety valve report_sender/server use) so the capture
+            # survives a transient DB outage and can be replayed later.
+            try:
+                from manyfaced.common.utils import dump_file
+
+                dump_file({'_dump_reason': 'sqlite_lock_contention', **record})
+            except Exception:  # noqa: BLE001 — last-resort fallback must never raise
+                logger.exception('Failed to dump record after lock contention')
 
     def close(self) -> None:
         """Close the SQLite connection with a final WAL checkpoint."""

--- a/test/test_storage/test_sqlite.py
+++ b/test/test_storage/test_sqlite.py
@@ -567,11 +567,20 @@ class TestInsertLockContention:
         assert calls['n'] >= 2  # at least one failure + one success
 
     def test_insert_gives_up_after_persistent_lock(self, tmp_path):
-        """Persistently locked DB is logged and the insert is dropped (no crash)."""
+        """Persistently locked DB is logged and the record is dumped (not lost)."""
         import sqlite3
+        from unittest.mock import patch
 
         db_path = str(tmp_path / 'locked2.db')
         storage = self._make_storage_with_mock_conn(db_path)
         storage._conn.execute.side_effect = sqlite3.OperationalError('database is locked')
-        storage.insert({'ip': '10.0.0.6'})  # must not raise
+
+        with patch('manyfaced.common.utils.dump_file') as mock_dump:
+            storage.insert({'ip': '10.0.0.6'})  # must not raise
         storage.close()
+
+        # The record must survive via the JSONL dump fallback, not be dropped.
+        mock_dump.assert_called_once()
+        dumped = mock_dump.call_args.args[0]
+        assert dumped['ip'] == '10.0.0.6'
+        assert dumped['_dump_reason'] == 'sqlite_lock_contention'


### PR DESCRIPTION
## Summary

Fixes #183. `SQLiteStorage.insert()` retried up to 5 times on `database is
locked`, then **silently dropped the record** — the exact failure mode the
`_WRITE_LOCK` serialization was meant to prevent from causing data loss, but
with no safety net when contention still wins.

## What changed
- When the retry loop exhausts and `last_exc` is a lock error, `insert()` now
  falls back to `dump_file()` (the existing JSONL safety valve used by
  `report_sender.py` / `server.py`) instead of discarding the capture. The
  dumped record carries `_dump_reason: 'sqlite_lock_contention'` so it can be
  identified and replayed.
- The fallback is wrapped so it can never raise (a last-resort dump must not
  crash the server child).
- Lazy import of `dump_file` to avoid import-order coupling.

## Verification
- Updated `TestInsertLockContention::test_insert_gives_up_after_persistent_lock`
  to assert the record is dumped (not dropped): `dump_file` called once with
  the original record + `_dump_reason`.
- `ruff` clean, `basedpyright` clean (0 errors/warnings).

## Risk
- Only adds a fallback path on the already-degraded "gave up" branch. Normal
  inserts are unchanged. Dump file is append-only and pre-existing.