### PR TITLE
migrate_db.py backup step before ALTER (issue #181)

### DIFF
--- a/scripts/migrate_db.py
+++ b/scripts/migrate_db.py
@@ -14,9 +14,12 @@ adding any missing columns.  It is:
   actually missing.
 * **Non-destructive** — it never drops or renames columns, and it runs a WAL
   checkpoint first so no uncommitted transactions are lost.
+* **Self-backing** — by default it writes a timestamped ``.bak`` copy of the
+  live DB (with WAL sidecars) before altering the schema, so a migration can
+  always be reverted.  Pass ``--no-backup`` to skip this.
 
 Usage:
-    python scripts/migrate_db.py [--db /path/to/honeypot.sqlite]
+    python scripts/migrate_db.py [--db /path/to/honeypot.sqlite] [--no-backup]
 
 Exit codes:
     0  migration applied successfully (or nothing to do)
@@ -26,7 +29,10 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import datetime
+import os
 import re
+import shutil
 import sqlite3
 import sys
 
@@ -66,7 +72,42 @@ def _parse_target_columns(create_sql: str) -> list[str]:
     return columns
 
 
-def migrate(db_path: str) -> int:
+def _backup(db_path: str) -> str | None:
+    """Copy the live DB (and WAL sidecars) to a timestamped ``.bak`` beside it.
+
+    SQLite in WAL mode keeps uncommitted data in the ``.sqlite-wal`` /
+    ``.sqlite-shm`` sidecars, so a backup must include them — or checkpoint
+    first and copy the main file.  We checkpoint into the main file, then copy
+    just the main file (plus any residual sidecars for safety) so the backup is
+    self-contained.
+
+    Returns the backup path, or None if the source does not exist.
+    """
+    if not os.path.exists(db_path):
+        return None
+    stamp = datetime.datetime.now().strftime('%Y%m%d%H%M%S')
+    backup_path = f'{db_path}.{stamp}.bak'
+    try:
+        src = sqlite3.connect(db_path)
+        src.execute('PRAGMA wal_checkpoint(TRUNCATE)')
+        src.close()
+    except sqlite3.Error as exc:
+        print(f'[migrate] WARNING: pre-backup checkpoint failed ({exc}); copying as-is.', file=sys.stderr)
+    try:
+        shutil.copy2(db_path, backup_path)
+        for sidecar in (f'{db_path}-wal', f'{db_path}-shm'):
+            if os.path.exists(sidecar):
+                shutil.copy2(sidecar, f'{backup_path}{sidecar[len(db_path):]}')
+    except OSError as exc:
+        print(f'[migrate] WARNING: backup copy failed ({exc}); proceeding without backup.', file=sys.stderr)
+        return None
+    print(f'[migrate] backup written: {backup_path}')
+    return backup_path
+
+
+def migrate(db_path: str, backup: bool = True) -> int:
+    if backup:
+        _backup(db_path)
     conn = None
     try:
         conn = sqlite3.connect(db_path)
@@ -108,8 +149,13 @@ def main() -> int:
         default='/opt/manyfaced/bots/honeypot.sqlite',
         help='Path to the honeypot SQLite database.',
     )
+    parser.add_argument(
+        '--no-backup',
+        action='store_true',
+        help='Skip the timestamped .bak copy written before migrating.',
+    )
     args = parser.parse_args()
-    return migrate(args.db)
+    return migrate(args.db, backup=not args.no_backup)
 
 
 if __name__ == '__main__':

--- a/scripts/migrate_db.py
+++ b/scripts/migrate_db.py
@@ -92,14 +92,20 @@ def _backup(db_path: str) -> str | None:
         src.execute('PRAGMA wal_checkpoint(TRUNCATE)')
         src.close()
     except sqlite3.Error as exc:
-        print(f'[migrate] WARNING: pre-backup checkpoint failed ({exc}); copying as-is.', file=sys.stderr)
+        print(
+            f'[migrate] WARNING: pre-backup checkpoint failed ({exc}); copying as-is.',
+            file=sys.stderr,
+        )
     try:
         shutil.copy2(db_path, backup_path)
         for sidecar in (f'{db_path}-wal', f'{db_path}-shm'):
             if os.path.exists(sidecar):
-                shutil.copy2(sidecar, f'{backup_path}{sidecar[len(db_path):]}')
+                shutil.copy2(sidecar, f'{backup_path}{sidecar[len(db_path) :]}')
     except OSError as exc:
-        print(f'[migrate] WARNING: backup copy failed ({exc}); proceeding without backup.', file=sys.stderr)
+        print(
+            f'[migrate] WARNING: backup copy failed ({exc}); proceeding without backup.',
+            file=sys.stderr,
+        )
         return None
     print(f'[migrate] backup written: {backup_path}')
     return backup_path

--- a/test/test_scripts/test_migrate_db.py
+++ b/test/test_scripts/test_migrate_db.py
@@ -118,3 +118,38 @@ def test_main_returns_error_code_on_failure(tmp_path: Path):
     with mock.patch.object(sys, 'argv', argv):
         rc = migrate_db.main()
     assert rc == 1
+
+
+def test_migrate_writes_backup_before_altering(tmp_path: Path):
+    """migrate() writes a timestamped .bak copy of the live DB by default."""
+    db = tmp_path / 'h.db'
+    conn = sqlite3.connect(db)
+    _make_table(conn, ['timestamp', 'ip'])  # missing bot_profile_data
+    conn.close()
+
+    before = list(tmp_path.glob('*.bak'))
+    rc = migrate_db.migrate(str(db))
+    after = list(tmp_path.glob('*.bak'))
+
+    assert rc == 0
+    # Exactly one new .bak file appeared and it is a copy of the pre-migration DB.
+    assert len(after) == len(before) + 1
+    bak = after[0]
+    assert bak.name.startswith('h.db.') and bak.name.endswith('.bak')
+    # The backup predates the migration: it lacks bot_profile_data.
+    bconn = sqlite3.connect(bak)
+    bnames = {r[1] for r in bconn.execute('PRAGMA table_info(honeypot_bears)')}
+    bconn.close()
+    assert 'bot_profile_data' not in bnames
+
+
+def test_migrate_skips_backup_with_flag(tmp_path: Path):
+    """backup=False leaves no .bak file behind."""
+    db = tmp_path / 'h.db'
+    conn = sqlite3.connect(db)
+    _make_table(conn, ['timestamp', 'ip'])
+    conn.close()
+
+    rc = migrate_db.migrate(str(db), backup=False)
+    assert rc == 0
+    assert not list(tmp_path.glob('*.bak'))


### PR DESCRIPTION
## Summary

Fixes #181. `migrate_db.py` was documented as "non-destructive" but ran an
`ALTER TABLE` with no backup, so a failed or partial migration had no clean
restore point.

## What changed
- `migrate()` now writes a best-effort timestamped backup (`<db>.<ts>.bak`,
  including WAL sidecars) **before** altering the schema. It checkpoints the
  live DB into the main file first so the backup is self-contained.
- New `--no-backup` flag skips the backup.
- Backup failures (locked/corrupt source) degrade to a warning and continue,
  so they can't abort the migration itself.
- Added tests: backup is written by default (and predates the migration), and
  `backup=False` leaves no `.bak` behind.

## Verification
- `test/test_scripts/test_migrate_db.py`: 9 passed (incl. 2 new backup tests).
- `ruff` clean, `basedpyright` clean.

## Risk
- `verify_deploy.sh` calls `migrate_db.py` with no flag, so each deploy now
  leaves one `.bak` beside the DB. That's the intended safety net; old
  backups can be pruned by a separate cleanup step if desired.