### PR TITLE
Double-checked locking for _get_router() singleton (issue #184)

### DIFF
--- a/manyfaced/handlers/http_handler.py
+++ b/manyfaced/handlers/http_handler.py
@@ -7,6 +7,7 @@ to protocol_responses module; report queue management to report_queue module.
 
 from __future__ import annotations
 
+import threading
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
@@ -52,20 +53,25 @@ from manyfaced.handlers.report_queue import _get_report_queue
 logger = get_logger(__name__)
 
 
-# Singleton router – initialized on first use
+# Singleton router – initialized on first use. Double-checked locking mirrors
+# _get_report_queue() so concurrent first requests on different multiport
+# accept-loop threads can't each build a separate Router instance.
 _router: Router | None = None
+_router_lock = threading.Lock()
 
 
 def _get_router() -> Router:
     """Get or create the module-level router (singleton)."""
     global _router
     if _router is None:
-        from manyfaced.handlers.routes import ROUTES  # noqa: F811
+        with _router_lock:
+            if _router is None:
+                from manyfaced.handlers.routes import ROUTES  # noqa: F811
 
-        from manyfaced.handlers.router import Router
+                from manyfaced.handlers.router import Router
 
-        _router = Router(ROUTES)
-        logger.info('Router initialized with %d routes', len(_router.routes))
+                _router = Router(ROUTES)
+                logger.info('Router initialized with %d routes', len(_router.routes))
     return _router
 
 

--- a/test/test_http_handler.py
+++ b/test/test_http_handler.py
@@ -782,3 +782,49 @@ class TestHandlerLRUCache:
 
         finally:
             handler.MAX_PROFILES = original_max
+
+
+class TestGetRouterSingleton:
+    """_get_router() must be a safe, single-instance lazy singleton (#184)."""
+
+    def test_concurrent_first_calls_return_one_instance(self):
+        """Many threads racing to build the router must share one instance.
+
+        Mirrors the multi-port startup race: several accept-loop threads can
+        each see _router is None and try to construct a Router simultaneously.
+        """
+        import threading
+
+        from manyfaced.handlers import http_handler as hh
+
+        # Force a fresh build so the race is exercised.
+        hh._router = None
+
+        results: list = []
+        barrier = threading.Barrier(8)
+        threads = []
+
+        def worker() -> None:
+            barrier.wait()  # release all threads at once
+            results.append(hh._get_router())
+
+        for _ in range(8):
+            t = threading.Thread(target=worker, daemon=True)
+            threads.append(t)
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(results) == 8
+        # All callers must receive the *same* singleton instance.
+        first = results[0]
+        assert all(r is first for r in results)
+        assert type(first).__name__ == 'Router'
+
+    def test_second_call_returns_cached_instance(self):
+        from manyfaced.handlers import http_handler as hh
+
+        hh._router = None
+        a = hh._get_router()
+        b = hh._get_router()
+        assert a is b


### PR DESCRIPTION
## Summary

Fixes #184. `_get_router()` in `manyfaced/handlers/http_handler.py` was a lazy
module-level singleton with no locking around its check-and-set, inconsistent
with the equivalent `_get_report_queue()` which uses proper double-checked
locking.

In multi-port mode (`create_multiport_server`) each port runs its own
accept-loop thread; if two receive their first-ever request concurrently
(realistic at startup), both can observe `_router is None` and build a separate
`Router`, silently discarding one.

## What changed
- Added `import threading` and a module-level `_router_lock`.
- `_get_router()` now uses double-checked locking (`if None → with lock → if
  None → build`), matching `_get_report_queue()`.
- Added `TestGetRouterSingleton` (concurrent-first-call race + cached-instance).

## Verification
- New tests pass (8 threads released via a `Barrier` all receive the same instance).
- `ruff` clean, `basedpyright` clean.

## Risk
- Locking only tightens the init path; callers are unaffected. Router is built
  once and cached exactly as before.