### PR TITLE
Retention jobs use _WRITE_LOCK; archive never loses unarchived rows (#178 #179)

### DIFF
--- a/manyfaced/db/storage.py
+++ b/manyfaced/db/storage.py
@@ -249,10 +249,9 @@ class SQLiteStorage(StorageBackend):
         if self._conn is None:
             logger.error('SQLite storage is not initialised; skipping delete')
             return 0
-
         cutoff = (datetime.now() - timedelta(days=days)).strftime('%Y-%m-%d %H:%M:%S.%f')
         try:
-            with self._lock:
+            with _WRITE_LOCK:
                 cursor = self._conn.execute(
                     'SELECT COUNT(*) FROM honeypot_bears WHERE timestamp < ?',
                     (cutoff,),
@@ -295,7 +294,7 @@ class SQLiteStorage(StorageBackend):
 
         cutoff = (datetime.now() - timedelta(days=days)).strftime('%Y-%m-%d %H:%M:%S.%f')
         try:
-            with self._lock:
+            with _WRITE_LOCK:
                 # Count records to archive
                 cursor = self._conn.execute(
                     'SELECT COUNT(*) FROM honeypot_bears WHERE timestamp < ?',
@@ -321,7 +320,8 @@ class SQLiteStorage(StorageBackend):
                 )
                 archive_conn.commit()
 
-                # Copy old records to archive
+                # Copy old records to archive, tracking which rows survived so a
+                # partial archive never deletes rows that didn't make it.
                 rows = self._conn.execute(
                     'SELECT * FROM honeypot_bears WHERE timestamp < ?',
                     (cutoff,),
@@ -333,23 +333,41 @@ class SQLiteStorage(StorageBackend):
                         'SELECT * FROM honeypot_bears LIMIT 0'
                     ).description
                 ]
+                id_index = col_names.index('id')
                 placeholders = ','.join(['?' for _ in col_names])
                 insert_sql = f'INSERT INTO honeypot_bears_archive VALUES ({placeholders})'
 
+                archived_ids: list[int] = []
                 with archive_conn:
                     for row in rows:
                         try:
                             archive_conn.execute(insert_sql, row)
+                            archived_ids.append(row[id_index])
                         except sqlite3.Error:
-                            logger.debug('Failed to archive row %s', row)
-
+                            # A row that fails to archive must NOT be deleted
+                            # from the main table — log it loudly so the data is
+                            # preserved until the archive can be retried.
+                            logger.warning(
+                                'Failed to archive row id=%s; leaving it in main DB', row[id_index]
+                            )
                 archive_conn.commit()
                 archive_conn.close()
 
-                # Delete archived records from main table
-                self._conn.execute('DELETE FROM honeypot_bears WHERE timestamp < ?', (cutoff,))
+                if not archived_ids:
+                    logger.error(
+                        'Archive copy failed for all %d rows; aborting delete to avoid data loss',
+                        count,
+                    )
+                    return None
+
+                # Delete only the rows that were actually archived.
+                placeholders_ids = ','.join(['?' for _ in archived_ids])
+                self._conn.execute(
+                    f'DELETE FROM honeypot_bears WHERE id IN ({placeholders_ids})',
+                    archived_ids,
+                )
                 self._conn.commit()
-                logger.info('Archived %d records to %s', count, dest_db)
+                logger.info('Archived %d/%d records to %s', len(archived_ids), count, dest_db)
 
                 return dest_db
 

--- a/test/test_storage/test_sqlite.py
+++ b/test/test_storage/test_sqlite.py
@@ -1,6 +1,7 @@
 """Tests for SQLiteStorage (init, insert, close, context manager, multiple inserts)."""
 
 import os
+import sqlite3
 from datetime import datetime
 from unittest.mock import patch
 
@@ -584,3 +585,103 @@ class TestInsertLockContention:
         dumped = mock_dump.call_args.args[0]
         assert dumped['ip'] == '10.0.0.6'
         assert dumped['_dump_reason'] == 'sqlite_lock_contention'
+
+
+class TestRetentionArchiveDelete:
+    """Coverage for retention jobs using the module-wide _WRITE_LOCK (#179)
+    and the archive-doesn't-lose-rows guarantee (#178)."""
+
+    def _seed(self, storage, rows):
+        """Insert rows directly into the storage connection (bypasses insert()).
+
+        rows: list of (id, bot_ip, hostname, timestamp) tuples.
+        """
+        ph = ','.join(['?'] * 4)
+        storage._conn.executemany(
+            f'INSERT INTO honeypot_bears (id, bot_ip, hostname, timestamp) VALUES ({ph})', rows
+        )
+        storage._conn.commit()
+
+    def test_archive_deletes_only_archived_rows(self, tmp_path):
+        """archive_old_records deletes only rows that were copied to archive."""
+        db = tmp_path / 'h.db'
+        storage = SQLiteStorage(db_path=str(db))
+        old_ts = '2000-01-01 00:00:00.000000'
+        new_ts = '2099-01-01 00:00:00.000000'
+        self._seed(
+            storage,
+            [
+                (1, '10.0.0.1', 'h1', old_ts),
+                (2, '10.0.0.2', 'h2', old_ts),
+                (3, '10.0.0.3', 'h3', new_ts),
+            ],
+        )
+
+        dest = str(tmp_path / 'archive.sqlite')
+        result = storage.archive_old_records(days=1, dest_db=dest)
+        storage.close()
+
+        assert result == dest
+        # Old rows gone from main, new row preserved.
+        main = sqlite3.connect(str(db))
+        remaining = {r[0] for r in main.execute('SELECT id FROM honeypot_bears')}
+        main.close()
+        assert remaining == {3}
+        # Both old rows present in archive.
+        arc = sqlite3.connect(dest)
+        archived = {r[0] for r in arc.execute('SELECT id FROM honeypot_bears_archive')}
+        arc.close()
+        assert archived == {1, 2}
+
+    def test_archive_keeps_rows_when_copy_fails(self, tmp_path):
+        """If the archive copy fails, no rows are deleted (no data loss)."""
+        db = tmp_path / 'h.db'
+        storage = SQLiteStorage(db_path=str(db))
+        old_ts = '2000-01-01 00:00:00.000000'
+        self._seed(storage, [(1, '10.0.0.1', 'h1', old_ts), (2, '10.0.0.2', 'h2', old_ts)])
+
+        # Break the archive DB so every row insert fails, but keep the main conn alive.
+        real_connect = sqlite3.connect
+
+        class _BrokenConn:
+            def __init__(self, conn):
+                self._conn = conn
+
+            def __getattr__(self, name):
+                return getattr(self._conn, name)
+
+            def execute(self, *args, **kwargs):
+                raise sqlite3.Error('disk full')
+
+        def _connect(path, *args, **kwargs):
+            conn = real_connect(path, *args, **kwargs)
+            if 'archive' in str(path):
+                return _BrokenConn(conn)
+            return conn
+
+        with patch('manyfaced.db.storage.sqlite3.connect', side_effect=_connect):
+            result = storage.archive_old_records(days=1)
+        storage.close()
+
+        # Archive aborted; main table must be untouched.
+        assert result is None
+        main = sqlite3.connect(str(db))
+        remaining = {r[0] for r in main.execute('SELECT id FROM honeypot_bears')}
+        main.close()
+        assert remaining == {1, 2}
+
+    def test_delete_old_records_removes_old_rows(self, tmp_path):
+        db = tmp_path / 'h.db'
+        storage = SQLiteStorage(db_path=str(db))
+        old_ts = '2000-01-01 00:00:00.000000'
+        new_ts = '2099-01-01 00:00:00.000000'
+        self._seed(storage, [(1, '10.0.0.1', 'h1', old_ts), (2, '10.0.0.2', 'h2', new_ts)])
+
+        deleted = storage.delete_old_records(days=1)
+        storage.close()
+
+        assert deleted == 1
+        main = sqlite3.connect(str(db))
+        remaining = {r[0] for r in main.execute('SELECT id FROM honeypot_bears')}
+        main.close()
+        assert remaining == {2}


### PR DESCRIPTION
## Summary

Fixes #179 and #178 in `manyfaced/db/storage.py`.

**#179 — locking:** `delete_old_records()` and `archive_old_records()` used the
per-instance `self._lock`, which `get_storage()`'s fresh-connection-per-call
model makes ineffective against concurrent inserts (the comment above
`_WRITE_LOCK` explains exactly why). Switched both to the module-wide
`_WRITE_LOCK` so they are genuinely serialized against `insert()`.

**#178 — data loss:** `archive_old_records()` logged per-row archive failures at
`debug` and then ran an *unconditional* `DELETE ... WHERE timestamp < cutoff`,
permanently dropping any row that failed to copy into the archive. Now it:
- tracks which rows actually archived (by `id`),
- deletes **only** those rows (explicit `id IN (...)`),
- logs failures at `warning`,
- and aborts the delete entirely (`return None`) if **no** rows archived, so a
  failed archive never silently deletes from the main table.

## Verification
- New `TestRetentionArchiveDelete` (3 tests): deletes-only-archived,
  keeps-rows-when-copy-fails, delete-removes-old. All pass.
- `ruff` clean, `basedpyright` clean (0 warnings).

## Risk
- Retention behavior is stricter (no silent deletes) but that is the point.
- `_WRITE_LOCK` is already held by `insert()`; retention now contends correctly
  instead of pretending to.