### PR TITLE
Add Dependabot config for pip + github-actions (issue #150)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Open PRs against the default branch; CI (lint/test/typecheck/drift) gates
+    # them and an agent reviews + merges. Relock with uv and commit uv.lock.
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "python"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Keeps the pinned action SHAs/versions in .github/workflows in sync.
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
## Summary
Addresses #150. The committed `uv.lock` (82KB) already pins the full resolved
dependency tree with hashes, so the lockfile half is satisfied and CI/deploy
install from it. This adds `.github/dependabot.yml` to automate updates:

- `pip` (root pyproject) — weekly, opens PRs relocking via uv.
- `github-actions` — weekly, keeps pinned workflow action SHAs/versions in sync.

Both are gated by the existing green-CI requirement (lint/test/typecheck/drift),
so agent review + merge applies to every bot PR.

## Verification
- YAML is valid Dependabot v2 config. No code/test changes.