### PR TITLE
Fix alerting env-var config, log_only=false, non-blocking dispatch (#172 #173 #174)

### DIFF
--- a/manyfaced/common/alerting.py
+++ b/manyfaced/common/alerting.py
@@ -22,7 +22,9 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import smtplib
+import threading
 from dataclasses import dataclass
 from email.mime.text import MIMEText
 from typing import Any
@@ -54,6 +56,20 @@ class AlertConfig:
     LOG_ONLY: bool = True  # If True, only log alerts (no external notifications)
 
 
+def _as_bool(value: Any, default: bool) -> bool:
+    """Coerce a TOML bool or env-string value to a bool.
+
+    Handles the case where TOML parses ``log_only = false`` to the Python value
+    ``False`` (which a naive ``value or 'true'`` would wrongly treat as
+    "falsy -> default true").
+    """
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    return str(value).strip().lower() in ('true', '1', 'yes', 'on')
+
+
 def _load_alert_config() -> AlertConfig:
     """Load alerting configuration from config.toml or environment variables."""
     try:
@@ -73,12 +89,12 @@ def _load_alert_config() -> AlertConfig:
 
     prefix = 'HONEY_ALERT_'
 
-    def env(key: str, default: Any = '') -> str:
-        return (
-            settings.__dict__.get(f'{prefix}{key}', default)
-            if hasattr(settings, f'{prefix}{key}')
-            else ''
-        )
+    def env(key: str, default: str = '') -> str:
+        # Read real process environment variables (the documented HONEY_ALERT_*
+        # config path). Previously this consulted settings.__dict__, which never
+        # carries these keys, so every lookup fell through to '' and silently
+        # discarded the caller's default too.
+        return os.environ.get(f'{prefix}{key}', default)
 
     # Load from TOML first, then override with environment variables
     telegram_token = alerting.get('telegram_bot_token', env('TELEGRAM_BOT_TOKEN', '')) or ''
@@ -95,10 +111,8 @@ def _load_alert_config() -> AlertConfig:
     to_emails_str = alerting.get('to_emails', env('TO_EMAILS', '')) or ''
     webhook_url = alerting.get('webhook_url', env('WEBHOOK_URL', '')) or ''
 
-    enabled_str = alerting.get('enabled', env('ENABLED', 'false')) or 'false'
-    log_only_str = alerting.get('log_only', env('LOG_ONLY', 'true')) or 'true'
-    enabled = str(enabled_str).lower() in ('true', '1', 'yes')
-    log_only = str(log_only_str).lower() in ('true', '1', 'yes')
+    enabled = _as_bool(alerting.get('enabled', env('ENABLED', 'false')), False)
+    log_only = _as_bool(alerting.get('log_only', env('LOG_ONLY', 'true')), True)
 
     to_emails = (
         tuple(e.strip() for e in to_emails_str.split(',') if e.strip()) if to_emails_str else ()
@@ -235,39 +249,19 @@ def send_webhook_alert(url: str, payload: dict[str, Any]) -> bool:
         return False
 
 
-def notify_credential_capture(
+def _deliver_credential_capture(
     ip: str,
     credentials: str,
-    path: str = '/',
-    hostname: str = '',
+    path: str,
+    hostname: str,
 ) -> None:
-    """Send notification when credentials are captured from a honeypot connection.
+    """Deliver credential-capture alerts via configured external channels.
 
-    This is the primary entry point for credential capture alerts. It logs at ERROR level
-    and optionally sends notifications via configured channels (Telegram, email, webhook).
-
-    Args:
-        ip: IP address of the bot that submitted credentials.
-        credentials: Captured credentials string (e.g., 'admin:password123').
-        path: Request path where credentials were captured.
-        hostname: Honeypot hostname/identifier that received the credentials.
+    Runs on a daemon background thread so the request-handling path that calls
+    ``notify_credential_capture`` is never blocked by a slow/unreachable
+    Telegram/SMTP/webhook endpoint (each has a 10s timeout; sequential delivery
+    could otherwise stall the request thread for ~30s — see issue #174).
     """
-    # Always log at ERROR level for visibility in logs
-    alert_message = (
-        f'⚠️ CREDENTIAL CAPTURE DETECTED\n'
-        f'IP: {ip}\n'
-        f'Credentials: {credentials}\n'
-        f'Path: {path}\n'
-        f'Honeypot: {hostname or "unknown"}\n'
-        f'Timestamp: {__import__("datetime").datetime.now().isoformat()}'
-    )
-
-    logger.error(alert_message)
-
-    # If only logging, don't send external notifications
-    if alert_config.LOG_ONLY:
-        return
-
     # Send Telegram notification if configured
     if alert_config.TELEGRAM_BOT_TOKEN and alert_config.TELEGRAM_CHAT_ID:
         telegram_msg = (
@@ -320,24 +314,54 @@ def notify_credential_capture(
         send_webhook_alert(alert_config.WEBHOOK_URL, payload)
 
 
-def send_alert(title: str, message: str) -> None:
-    """Send a generic alert via configured channels.
+def notify_credential_capture(
+    ip: str,
+    credentials: str,
+    path: str = '/',
+    hostname: str = '',
+) -> None:
+    """Send notification when credentials are captured from a honeypot connection.
 
-    This is a general-purpose alert function for future use (e.g., system warnings,
-    database errors, etc.). Currently only logs at ERROR level unless external
-    notification channels are configured.
+    This is the primary entry point for credential capture alerts. It logs at ERROR level
+    and optionally sends notifications via configured channels (Telegram, email, webhook).
+
+    The ERROR-level log is written synchronously (cheap); external delivery is dispatched
+    to a daemon background thread so a slow/unreachable channel cannot stall the request
+    thread that reported the capture (issue #174).
 
     Args:
-        title: Alert title/summary.
-        message: Detailed alert message.
+        ip: IP address of the bot that submitted credentials.
+        credentials: Captured credentials string (e.g., 'admin:password123').
+        path: Request path where credentials were captured.
+        hostname: Honeypot hostname/identifier that received the credentials.
     """
-    alert_text = f'⚠️ {title}\n{message}'
-    logger.error(alert_text)
+    # Always log at ERROR level for visibility in logs
+    alert_message = (
+        f'⚠️ CREDENTIAL CAPTURE DETECTED\n'
+        f'IP: {ip}\n'
+        f'Credentials: {credentials}\n'
+        f'Path: {path}\n'
+        f'Honeypot: {hostname or "unknown"}\n'
+        f'Timestamp: {__import__("datetime").datetime.now().isoformat()}'
+    )
 
+    logger.error(alert_message)
+
+    # If only logging, don't send external notifications
     if alert_config.LOG_ONLY:
         return
 
-    # Send via all configured channels
+    # Dispatch external notifications off the request thread (issue #174).
+    threading.Thread(
+        target=_deliver_credential_capture,
+        args=(ip, credentials, path, hostname),
+        daemon=True,
+        name='alert-delivery',
+    ).start()
+
+
+def _deliver_alert(title: str, message: str) -> None:
+    """Deliver a generic alert via configured channels (background worker)."""
     if alert_config.TELEGRAM_BOT_TOKEN and alert_config.TELEGRAM_CHAT_ID:
         send_telegram_message(
             alert_config.TELEGRAM_BOT_TOKEN,
@@ -362,6 +386,34 @@ def send_alert(title: str, message: str) -> None:
             alert_config.WEBHOOK_URL,
             {'event': 'alert', 'title': title, 'message': message},
         )
+
+
+def send_alert(title: str, message: str) -> None:
+    """Send a generic alert via configured channels.
+
+    This is a general-purpose alert function for future use (e.g., system warnings,
+    database errors, etc.). Currently only logs at ERROR level unless external
+    notification channels are configured.
+
+    External delivery is dispatched to a daemon background thread so it cannot
+    block the caller (issue #174).
+
+    Args:
+        title: Alert title/summary.
+        message: Detailed alert message.
+    """
+    alert_text = f'⚠️ {title}\n{message}'
+    logger.error(alert_text)
+
+    if alert_config.LOG_ONLY:
+        return
+
+    threading.Thread(
+        target=_deliver_alert,
+        args=(title, message),
+        daemon=True,
+        name='alert-delivery',
+    ).start()
 
 
 __all__ = [

--- a/test/test_alerting.py
+++ b/test/test_alerting.py
@@ -142,22 +142,73 @@ class TestAlertConfigDataclass:
         assert config.LOG_ONLY is True
 
 
-class TestIntegration:
-    """Integration tests for alerting system."""
+class TestAlertingFixes:
+    """Regression tests for issues #172, #173, #174."""
 
-    def test_notify_credential_capture_integration(self):
-        """Test full integration of credential capture notification."""
-        from manyfaced.common.alerting import notify_credential_capture, alert_config
+    def test_env_vars_are_read(self, monkeypatch):
+        """#172: HONEY_ALERT_* environment variables must be picked up."""
+        import os
 
-        # This should not raise any exceptions even with default config
-        notify_credential_capture(
-            ip='192.168.1.100',
-            credentials='admin:secret123',
-            path='/login',
-            hostname='production-honeypot',
-        )
+        monkeypatch.setenv('HONEY_ALERT_WEBHOOK_URL', 'https://example.test/hook')
+        monkeypatch.setenv('HONEY_ALERT_TELEGRAM_BOT_TOKEN', 'tok123')
+        monkeypatch.setenv('HONEY_ALERT_SMTP_HOST', 'smtp.example.test')
+        # Ensure no TOML overrides it.
+        monkeypatch.delenv('HONEY_ALERT_CONFIG', raising=False)
 
-        # Verify it completed without errors (logging is the only action with default config)
+        from manyfaced.common.alerting import _load_alert_config
+
+        cfg = _load_alert_config()
+        assert cfg.WEBHOOK_URL == 'https://example.test/hook'
+        assert cfg.TELEGRAM_BOT_TOKEN == 'tok123'
+        assert cfg.SMTP_HOST == 'smtp.example.test'
+
+    def test_log_only_false_from_toml(self, tmp_path, monkeypatch):
+        """#173: log_only = false in config.toml must take effect (not coerce to true)."""
+        from types import SimpleNamespace
+
+        from manyfaced.common import config
+
+        cfg_path = tmp_path / 'alert.toml'
+        cfg_path.write_text('[alerting]\nenabled = true\nlog_only = false\n', encoding='utf-8')
+        # _load_alert_config reads settings.ALERT_CONFIG (frozen Config can't be
+        # setattr'd), so swap the module-level settings object for a stand-in.
+        monkeypatch.setattr(config, 'settings', SimpleNamespace(ALERT_CONFIG=str(cfg_path)))
+
+        from manyfaced.common.alerting import _load_alert_config
+
+        cfg = _load_alert_config()
+        assert cfg.LOG_ONLY is False
+        assert cfg.ENABLED is True
+
+    def test_as_bool_coerces_toml_false(self):
+        """#173: _as_bool must treat a TOML-parsed False as False (not fall back to default)."""
+        from manyfaced.common.alerting import _as_bool
+
+        assert _as_bool(False, True) is False
+        assert _as_bool(True, False) is True
+        assert _as_bool('false', True) is False
+        assert _as_bool('true', False) is True
+        assert _as_bool(None, True) is True
+
+    def test_notify_dispatches_background_thread(self, caplog):
+        """#174: notify_credential_capture must not block the caller; it spawns a daemon thread."""
+        import logging
+        import threading
+
+        from manyfaced.common import alerting
+        from manyfaced.common.alerting import notify_credential_capture
+
+        # Force external delivery path (not LOG_ONLY).
+        with patch.object(
+            alerting, 'alert_config', alerting.AlertConfig(LOG_ONLY=False, WEBHOOK_URL='https://x')
+        ):
+            with caplog.at_level(logging.ERROR):
+                notify_credential_capture(ip='9.9.9.9', credentials='u:p', path='/x')
+            # The caller returns immediately; delivery runs on a background thread.
+            threads = [t for t in threading.enumerate() if t.name == 'alert-delivery']
+            assert threads, 'expected an alert-delivery background thread to be spawned'
+            for t in threads:
+                t.join(timeout=2)
 
 
 __all__ = [
@@ -165,5 +216,5 @@ __all__ = [
     'TestAlertConfig',
     'TestSendFunctions',
     'TestAlertConfigDataclass',
-    'TestIntegration',
+    'TestAlertingFixes',
 ]


### PR DESCRIPTION
## Summary
Fixes three bugs in `manyfaced/common/alerting.py` (all introduced in #156):

**#172 — dead `HONEY_ALERT_*` env path.** `_load_alert_config()`'s `env()` helper read `settings.__dict__`, which never carries `HONEY_ALERT_*` keys, so env config was silently dead (and the caller's default was discarded). Now reads `os.environ` directly via the `HONEY_ALERT_` prefix.

**#173 — `log_only = false` could never take effect.** TOML parses `log_only = false` to Python `False`, but `False or 'true'` coerced it back to `true`. Added a proper `_as_bool()` that respects bool/string/None values.

**#174 — hot-path blocking.** `notify_credential_capture()`/`send_alert()` ran Telegram+SMTP+webhook synchronously on the request thread (up to ~30s of sequential 10s timeouts), reintroducing the blocking #124 fixed for geo. Delivery now dispatches to a daemon background thread; the ERROR log stays synchronous.

## Verification
- `TestAlertingFixes`: env vars picked up (#172), `log_only=false` TOML takes effect (#173), `notify_*` spawns an `alert-delivery` daemon thread and returns immediately (#174).
- Direct `_as_bool` unit test.
- `ruff` clean, `basedpyright` clean (0 warnings).