### PR TITLE
Bound geolocate cache with LRU eviction + TTL (#175)

### DIFF
--- a/manyfaced/common/geolocate.py
+++ b/manyfaced/common/geolocate.py
@@ -22,7 +22,15 @@ logger = logging.getLogger(__name__)
 # Rate limiting: ip-api.com allows 45 requests per minute
 _RATE_LIMIT_DELAY = 60 / 45  # ~1.33 seconds between requests
 _last_geo_lookup_time: float = 0
-_geo_cache: dict[str, tuple[str, str]] = {}
+
+# Bounded cache: a honeypot is hit by a high volume of distinct attacker IPs
+# over its lifetime, so an unbounded module-level dict would grow monotonically
+# and eventually OOM (see issue #175). Entries expire after _GEO_CACHE_TTL
+# seconds and the dict is capped at _GEO_CACHE_MAX_SIZE entries (LRU eviction).
+_GEO_CACHE_TTL = 24 * 60 * 60  # 24h
+_GEO_CACHE_MAX_SIZE = 10_000
+# value -> (country, continent, expires_at)
+_geo_cache: dict[str, tuple[str, str, float]] = {}
 _geo_cache_lock = threading.Lock()
 
 # Background worker for async geo lookups
@@ -55,11 +63,16 @@ def lookup_ip_geolocation(ip: str, timeout: float = 2.0) -> tuple[str, str]:
     if ip in ('127.0.0.1', '::1') or ip.startswith(('10.', '192.168.', '172.')):
         return ('', '')
 
-    # Check cache first (thread-safe)
+    # Check cache first (thread-safe); entries past their TTL are treated as
+    # a miss so stale geo data is eventually refreshed and memory is reclaimed.
+    now = time.monotonic()
     with _geo_cache_lock:
-        cached = _geo_cache.get(ip)
-        if cached:
-            return cached
+        entry = _geo_cache.get(ip)
+        if entry is not None and entry[2] > now:
+            # Move to the end to mark as most-recently-used (LRU).
+            del _geo_cache[ip]
+            _geo_cache[ip] = entry
+            return entry[0], entry[1]
 
     # Not cached — schedule background lookup and return empty immediately
     start_geo_worker()
@@ -95,17 +108,34 @@ def _do_geo_lookup(ip: str, timeout: float = 2.0) -> tuple[str, str]:
             result = (country, continent)
 
         # Update cache and rate-limit timestamp
-        with _geo_cache_lock:
-            _geo_cache[ip] = result
+        _store_geo(ip, result)
         _last_geo_lookup_time = time.monotonic()
         return result
 
     except Exception as e:
         logger.warning('Geo lookup failed for %s: %s', ip, e)
         # On failure, cache empty result to avoid repeated lookups
-        with _geo_cache_lock:
-            _geo_cache[ip] = ('', '')
+        _store_geo(ip, ('', ''))
         return ('', '')
+
+
+def _store_geo(ip: str, result: tuple[str, str]) -> None:
+    """Store a geo result in the bounded, TTL-scoped cache.
+
+    Marks the entry as most-recently-used and evicts the oldest entries when
+    the cache exceeds ``_GEO_CACHE_MAX_SIZE`` (LRU eviction) — this caps process
+    memory regardless of how many distinct attacker IPs are seen (issue #175).
+    """
+    expires_at = time.monotonic() + _GEO_CACHE_TTL
+    with _geo_cache_lock:
+        _geo_cache.pop(ip, None)
+        if len(_geo_cache) >= _GEO_CACHE_MAX_SIZE:
+            # Evict the oldest entries; dicts preserve insertion order so the
+            # first key is the least-recently-used.
+            evict_count = len(_geo_cache) - _GEO_CACHE_MAX_SIZE + 1
+            for stale_ip in list(_geo_cache)[:evict_count]:
+                _geo_cache.pop(stale_ip, None)
+        _geo_cache[ip] = (result[0], result[1], expires_at)
 
 
 def start_geo_worker() -> None:

--- a/test/test_geolocate.py
+++ b/test/test_geolocate.py
@@ -84,7 +84,7 @@ def test_private_ip_returns_empty():
 def test_cache_reuse():
     """Repeated lookups for the same IP should return cached results without another HTTP call."""
     with _geo_cache_lock:
-        _geo_cache['203.0.113.1'] = ('Japan', 'Asia')
+        _geo_cache['203.0.113.1'] = ('Japan', 'Asia', time.monotonic() + 1000)
 
     country, continent = lookup_ip_geolocation('203.0.113.1')
     assert country == 'Japan'
@@ -94,7 +94,7 @@ def test_cache_reuse():
 def test_cache_is_thread_safe():
     """Cache reads/writes should be thread-safe (use lock)."""
     with _geo_cache_lock:
-        _geo_cache['test.ip'] = ('Test', 'Test')
+        _geo_cache['test.ip'] = ('Test', 'Test', time.monotonic() + 1000)
 
     country, continent = lookup_ip_geolocation('test.ip')
     assert country == 'Test'
@@ -112,7 +112,7 @@ def test_background_worker_processes_lookups():
     def mock_do_geo_lookup(ip, timeout=2.0):
         # Simulate a successful lookup AND write to cache (like real _do_geo_lookup does)
         with _geo_cache_lock:
-            _geo_cache[ip] = ('France', 'Europe')
+            _geo_cache[ip] = ('France', 'Europe', time.monotonic() + 1000)
         return ('France', 'Europe')
 
     start_geo_worker()
@@ -138,7 +138,7 @@ def test_background_worker_rate_limits():
 
     def mock_do_geo_lookup(ip, timeout=2.0):
         with patch('time.sleep') as mock_sleep:
-            result = ('Test', 'Test')
+            result = ('Test', 'Test', time.monotonic() + 1000)
             if mock_sleep.call_count > 0:
                 sleep_times.append(mock_sleep.call_args[0][0])
             return result
@@ -180,7 +180,7 @@ def test_failure_response_logs_warning():
 
     def mock_do_geo_lookup(ip, timeout=2.0):
         with _geo_cache_lock:
-            _geo_cache[ip] = ('', '')
+            _geo_cache[ip] = ('', '', time.monotonic() + 1000)
         return ('', '')
 
     # Keep patch active while waiting for worker to process
@@ -210,7 +210,7 @@ def test_empty_response_returns_empty():
 
     def mock_do_geo_lookup(ip, timeout=2.0):
         with _geo_cache_lock:
-            _geo_cache[ip] = ('', '')
+            _geo_cache[ip] = ('', '', time.monotonic() + 1000)
         return ('', '')
 
     # Keep patch active while waiting for worker to process
@@ -237,7 +237,7 @@ def test_success_response_populates_cache():
 
     def mock_do_geo_lookup(ip, timeout=2.0):
         with _geo_cache_lock:
-            _geo_cache[ip] = ('Germany', 'Europe')
+            _geo_cache[ip] = ('Germany', 'Europe', time.monotonic() + 1000)
         return ('Germany', 'Europe')
 
     # Keep patch active while waiting for worker to process
@@ -261,3 +261,41 @@ def test_success_response_populates_cache():
 # ---------------------------------------------------------------------------
 # Helper: patch is imported above for test mocking.
 # ---------------------------------------------------------------------------
+
+
+# ===================================================================
+# Test 9: cache is bounded — no unbounded memory growth (issue #175)
+# ===================================================================
+
+
+def test_cache_evicts_oldest_when_over_max_size():
+    """_store_geo evicts the least-recently-used entries past _GEO_CACHE_MAX_SIZE."""
+    from manyfaced.common.geolocate import _GEO_CACHE_MAX_SIZE, _store_geo
+
+    # Fill to the cap with valid (unexpired) entries.
+    for i in range(_GEO_CACHE_MAX_SIZE):
+        _store_geo(f'10.0.0.{i}', (f'C{i}', 'X'))
+
+    with _geo_cache_lock:
+        assert len(_geo_cache) == _GEO_CACHE_MAX_SIZE
+
+    # One more insertion must evict exactly one oldest entry, never exceed the cap.
+    _store_geo('10.255.255.255', ('New', 'Y'))
+    with _geo_cache_lock:
+        assert len(_geo_cache) == _GEO_CACHE_MAX_SIZE
+        # The very first (LRU) entry should have been evicted.
+        assert '10.0.0.0' not in _geo_cache
+        # The newest entry is present.
+        assert '10.255.255.255' in _geo_cache
+
+
+def test_cache_expired_entries_are_not_returned():
+    """A cached entry past its TTL behaves as a miss (issue #175 — TTL scope)."""
+    # Store with an already-expired timestamp.
+    with _geo_cache_lock:
+        _geo_cache['9.9.9.9'] = ('Old', 'Country', time.monotonic() - 1)
+
+    # The lookup must not return the stale value; it schedules a refresh.
+    country, continent = lookup_ip_geolocation('9.9.9.9')
+    assert country == ''
+    assert continent == ''


### PR DESCRIPTION
## Summary
Fixes #175 — `_geo_cache` in `manyfaced/common/geolocate.py` grew unbounded for the process lifetime (no eviction/TTL/cap), a slow OOM path on a long-lived honeypot (see #168).

- Entries now carry an expiry (`_GEO_CACHE_TTL = 24h`).
- Dict capped at `_GEO_CACHE_MAX_SIZE = 10000` with LRU eviction via a new `_store_geo()` helper (marks entries most-recently-used; evicts oldest when over capacity).
- Reads treat expired entries as misses (stale geo data is eventually refreshed, memory reclaimed).

## Verification
- `Test 9`: `test_cache_evicts_oldest_when_over_max_size` (LRU eviction at cap), `test_cache_expired_entries_are_not_returned` (TTL miss).
- Existing geolocate tests updated for the `(country, continent, expires_at)` tuple shape.
- `ruff` clean, `basedpyright` clean (0 warnings), 12 geolocate tests pass.