### PR TITLE
Close geolocate queue TOCTOU race on shutdown/restart (#171)

### DIFF
--- a/manyfaced/common/geolocate.py
+++ b/manyfaced/common/geolocate.py
@@ -76,8 +76,10 @@ def lookup_ip_geolocation(ip: str, timeout: float = 2.0) -> tuple[str, str]:
 
     # Not cached — schedule background lookup and return empty immediately
     start_geo_worker()
-    assert _geo_queue is not None  # type: ignore[assertion-error]
-    _geo_queue.put((ip, timeout))  # noqa: SLF001
+    queue = _geo_queue
+    if queue is None:  # Worker failed to start; don't block the hot path
+        return ('', '')
+    queue.put((ip, timeout))  # noqa: SLF001
     return ('', '')
 
 
@@ -154,15 +156,20 @@ def _geo_worker_loop() -> None:
     """Background worker loop that processes geo lookup requests from the queue."""
     while True:
         try:
-            if _geo_queue is None:
+            queue = _geo_queue
+            if queue is None:
                 break  # Queue was destroyed during shutdown
-            item = _geo_queue.get(timeout=1.0)  # Periodic wake to check for shutdown
+            item = queue.get(timeout=1.0)  # Periodic wake to check for shutdown
             if item is None:
                 break  # Shutdown signal
             ip, timeout = item
             _do_geo_lookup(ip, timeout=timeout)
         except Empty:
             continue
+        except AttributeError:
+            # _geo_queue was reset to None concurrently with the local capture;
+            # treat as shutdown signal rather than crashing the worker (issue #171).
+            break
 
 
 def stop_geo_worker() -> None:

--- a/test/test_geolocate.py
+++ b/test/test_geolocate.py
@@ -299,3 +299,28 @@ def test_cache_expired_entries_are_not_returned():
     country, continent = lookup_ip_geolocation('9.9.9.9')
     assert country == ''
     assert continent == ''
+
+
+def test_stop_worker_does_not_crash_producer_or_consumer():
+    """Concurrent stop_geo_worker() must not crash the request thread or worker (#171)."""
+    import concurrent.futures
+
+    start_geo_worker()
+
+    def hammer():
+        # Repeatedly look up + stop the worker; races must not raise AttributeError.
+        for _ in range(50):
+            try:
+                lookup_ip_geolocation('198.51.100.7')
+            except AttributeError:
+                raise  # TOCTOU crash would surface here
+            stop_geo_worker()
+
+    # Run several threads hammering lookup/stop concurrently.
+    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as ex:
+        futures = [ex.submit(hammer) for _ in range(4)]
+        for f in futures:
+            f.result()  # raises if any thread hit the AttributeError race
+
+    # No assertion failure == no crash. Worker cleanup.
+    stop_geo_worker()


### PR DESCRIPTION
## Summary
Fixes #171 — a check-then-act TOCTOU race on the module-global `_geo_queue` between `stop_geo_worker()` and the producer (`lookup_ip_geolocation`) / consumer (`_geo_worker_loop`).

**Before:** both did `if _geo_queue is None: ...` then a separate `_geo_queue.put()/.get()` re-reading the global. If `stop_geo_worker()` reset `_geo_queue` to `None` concurrently, `.put()/.get()` raised `AttributeError`: the request-handling thread crashed, or the daemon worker died silently (contradicting #154's claim that the worker "handles None queue gracefully").

**After:** capture `_geo_queue` into a local after the None-check and use that local for the subsequent `put`/`get`. Producer returns `('', '')` (not an assert) if the worker didn't start; consumer catches `AttributeError` and treats it as a shutdown signal.

## Verification
- `test_stop_worker_does_not_crash_producer_or_consumer`: 4 threads hammer lookup/stop concurrently; fails if the `AttributeError` race surfaces.
- `ruff` clean, `basedpyright` clean, all 13 geolocate tests pass.