### PR TITLE
Guard against relative DB_PATH splitting recording (#188)

### DIFF
--- a/manyfaced/db/storage.py
+++ b/manyfaced/db/storage.py
@@ -75,8 +75,8 @@ class StorageBackend(ABC):
 _PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
 
 
-def _resolve_db_path() -> str:
-    """Return the SQLite database path.
+def _raw_db_path() -> str:
+    """Return the configured DB path WITHOUT the relative->absolute rewrite.
 
     Precedence (highest to lowest):
       1. HONEY_DB_PATH environment variable
@@ -98,6 +98,49 @@ def _resolve_db_path() -> str:
         pass
 
     return 'bots/honeypot.sqlite'
+
+
+def _resolve_db_path() -> str:
+    """Return the absolute SQLite database path, rewriting relative paths.
+
+    A relative path is a footgun: the server's CWD (the ``current`` release
+    symlink) is orphaned on every deploy, so writes would land in a fresh,
+    empty file each deploy while operators inspect the long-lived DB — the
+    "honeypot silently not recording" symptom (issue #188). Relative paths are
+    therefore rewritten to absolute paths under the project root and a loud
+    warning is emitted so the operator notices the misconfiguration.
+
+    Use :func:`validate_db_path_absolute` to detect a relative *configuration*
+    (before the rewrite) so a deploy/CI gate can fail fast.
+    """
+    resolved = _raw_db_path()
+    if not os.path.isabs(resolved):
+        # Rewrite relative -> absolute under the project root so the DB at
+        # least survives deploys instead of being orphaned by the CWD symlink.
+        abs_path = os.path.abspath(os.path.join(_PROJECT_ROOT, resolved))
+        logger.warning(
+            'DB path %r is relative; under systemd the CWD (%s) is orphaned on '
+            'every deploy and writes would be lost. Rewriting to absolute %r '
+            '(issue #188). Set HONEY_DB_PATH (or database.path in config) to an '
+            'absolute, long-lived path to silence this.',
+            resolved,
+            _PROJECT_ROOT,
+            abs_path,
+        )
+        return abs_path
+
+    return resolved
+
+
+def validate_db_path_absolute() -> bool:
+    """Return True if the *configured* (raw) DB path is absolute (deploy/CI guard).
+
+    Unlike :func:`_resolve_db_path`, this does NOT apply the defensive
+    relative->absolute rewrite, so it reports the actual configuration. A
+    deploy/CI step should fail when this returns False to prevent recording
+    from splitting onto an orphaned CWD-relative database (issue #188).
+    """
+    return os.path.isabs(_raw_db_path())
 
 
 def _resolve_backend() -> str:
@@ -544,4 +587,5 @@ __all__ = [
     'PostgreSQLStorage',
     'get_storage',
     'backup_database',
+    'validate_db_path_absolute',
 ]

--- a/scripts/verify_deploy.sh
+++ b/scripts/verify_deploy.sh
@@ -19,6 +19,26 @@ if [ -f /opt/manyfaced/honeypot.env ]; then
   set -a; . /opt/manyfaced/honeypot.env; set +a
 fi
 
+# 0) Guard: the resolved DB path MUST be absolute. A relative path under the
+# systemd CWD (the orphaned `current` symlink) would split recording onto a
+# deploy-orphaned file while operators inspect the real DB — the 2026-07
+# silent-stop (issue #188). The code rewrites relative->absolute defensively,
+# but a deploy onto a misconfigured droplet must FAIL here rather than ship
+# silent data loss.
+echo "== Verifying DB path is absolute =="
+"$VENV" - <<'PY'
+from manyfaced.db.storage import validate_db_path_absolute
+
+if not validate_db_path_absolute():
+    print("ERROR: configured DB path is NOT absolute (relative to CWD).")
+    print("A relative HONEY_DB_PATH/database.path under the systemd CWD (the")
+    print("orphaned 'current' symlink) splits recording onto a deploy-orphaned")
+    print("file while operators inspect the real DB (issue #188). Set it to an")
+    print("absolute, long-lived path such as /opt/manyfaced/bots/honeypot.sqlite.")
+    raise SystemExit(1)
+print("OK: DB path is absolute")
+PY
+
 CURRENT_TARGET="$(readlink -f /opt/manyfaced/current 2>/dev/null || echo /opt/manyfaced/releases/current)"
 VENV="${CURRENT_TARGET}/venv/bin/python3"
 [ -x "$VENV" ] || VENV="/opt/manyfaced/venv/bin/python3"

--- a/test/test_storage/test_config.py
+++ b/test/test_storage/test_config.py
@@ -3,8 +3,21 @@
 import os
 from unittest.mock import patch
 
+# Keep HOME/USERPROFILE intact: config.py's Config.load() reads Path.home(),
+# which raises on Windows when the env is fully cleared (patch.dict clear=True
+# wipes USERPROFILE). We only need to guarantee HONEY_DB_PATH is absent.
+_env_no_db = {k: v for k, v in os.environ.items() if k != 'HONEY_DB_PATH'}
+
 # Imports handled by conftest.py sys.path setup
-from manyfaced.db.storage import _resolve_backend, _resolve_db_path  # noqa: E402
+from manyfaced.db import storage  # noqa: E402
+from manyfaced.db.storage import (  # noqa: E402
+    _resolve_backend,
+    _resolve_db_path,
+    validate_db_path_absolute,
+)
+
+
+_PROJECT_ROOT = storage._PROJECT_ROOT
 
 
 # ---------------------------------------------------------------------------
@@ -15,22 +28,27 @@ from manyfaced.db.storage import _resolve_backend, _resolve_db_path  # noqa: E40
 class TestResolveDbPath:
     """Tests for _resolve_db_path()."""
 
-    def test_default_path_when_env_not_set(self):
+    def test_default_path_becomes_absolute_under_root(self):
+        """Default relative fallback is rewritten to an absolute path (issue #188)."""
         with (
-            patch.dict(os.environ, {}, clear=True),
+            patch.dict(os.environ, _env_no_db, clear=True),
             patch('manyfaced.common.config.settings', DB_PATH=None),
         ):
             result = _resolve_db_path()
-        assert result == 'bots/honeypot.sqlite'
+        assert os.path.isabs(result)
+        assert result.endswith(os.path.join('bots', 'honeypot.sqlite'))
 
     def test_falls_back_to_toml_config_db_path(self):
         """When no env var is set, falls back to TOML config's database.path."""
         with (
-            patch.dict(os.environ, {}, clear=True),
+            patch.dict(os.environ, _env_no_db, clear=True),
             patch('manyfaced.common.config.settings', DB_PATH='/custom/from/toml.db'),
         ):
             result = _resolve_db_path()
-        assert result == '/custom/from/toml.db'
+        # Unix-style path has no drive letter so it's treated as relative on
+        # Windows and rewritten to absolute; assert it resolves to that target.
+        assert os.path.isabs(result)
+        assert result.replace('\\', '/').endswith('/custom/from/toml.db')
 
     def test_env_overrides_toml_config(self):
         """HONEY_DB_PATH env var takes precedence over TOML config."""
@@ -39,17 +57,36 @@ class TestResolveDbPath:
             patch('manyfaced.common.config.settings', DB_PATH='/toml/path.db'),
         ):
             result = _resolve_db_path()
-        assert result == '/env/override.db'
+        assert os.path.isabs(result)
+        assert result.replace('\\', '/').endswith('/env/override.db')
 
     def test_custom_path_from_env(self):
         with patch.dict(os.environ, {'HONEY_DB_PATH': '/tmp/custom.db'}, clear=True):
             result = _resolve_db_path()
-        assert result == '/tmp/custom.db'
+        assert os.path.isabs(result)
+        assert result.replace('\\', '/').endswith('/tmp/custom.db')
 
-    def test_env_path_with_subdirs(self):
+    def test_relative_env_path_rewritten_to_absolute(self):
+        """A relative HONEY_DB_PATH is rewritten to absolute under the project root (#188)."""
         with patch.dict(os.environ, {'HONEY_DB_PATH': 'data/nested/honeypot.db'}, clear=True):
             result = _resolve_db_path()
-        assert result == 'data/nested/honeypot.db'
+        assert os.path.isabs(result)
+        assert result.endswith(os.path.join('data', 'nested', 'honeypot.db'))
+        assert result.startswith(_PROJECT_ROOT)
+
+    def test_validate_db_path_absolute_true_for_absolute(self):
+        """validate_db_path_absolute() returns True when the configured path is absolute."""
+        abs_path = os.path.abspath('/abs/path/db.sqlite')
+        with patch.dict(os.environ, {'HONEY_DB_PATH': abs_path}, clear=True):
+            assert validate_db_path_absolute() is True
+
+    def test_validate_db_path_absolute_false_for_relative_default(self):
+        """validate_db_path_absolute() returns False for the relative default (CI/deploy guard)."""
+        with (
+            patch.dict(os.environ, _env_no_db, clear=True),
+            patch('manyfaced.common.config.settings', DB_PATH=None),
+        ):
+            assert validate_db_path_absolute() is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes #188 — the root cause of the "honeypot silently not recording" symptom: a relative `HONEY_DB_PATH`/`database.path` resolves against the systemd CWD (the orphaned `current` release symlink), so writes land in a fresh, deploy-orphaned file while operators inspect the real DB.

**Changes:**
- `_resolve_db_path()` rewrites any relative path to an absolute path under the project root and emits a loud warning. Defensive: data still lands in a long-lived location instead of being silently lost.
- `validate_db_path_absolute()` checks the **raw configured** path (no rewrite) so a deploy/CI gate can FAIL when a relative path is configured.
- `verify_deploy.sh` now runs this guard and aborts the deploy on a relative path (acceptance #2).
- Tests updated for the rewrite + absolute guard; ported to OS-agnostic path assertions.

## Verification
- `ruff` + `basedpyright` clean.
- 12 storage-config tests pass (local Windows; CI Linux is the source of truth).
- `bash -n scripts/verify_deploy.sh` valid.